### PR TITLE
feat: Use TV/Movies/Album by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ clients:
       apikey: YOUR_API_KEY
       filters:
         - 15
+      #matchRelease: false / true
 
     - name: sonarr
       type: sonarr
@@ -37,6 +38,7 @@ clients:
         pass: password
       filters:
         - 14
+      #matchRelease: false / true
 
     - name: lidarr
       type: lidarr
@@ -44,6 +46,7 @@ clients:
       apikey: YOUR_API_KEY
       filters:
         - 13
+      #matchRelease: false / true
 
     - name: readarr
       type: readarr
@@ -108,6 +111,12 @@ If you want to exclude certain tags, you can use the `tagsExclude`.
   tagsExclude:
     - myothertag
 ```
+
+## Optionally use Match Releases field in your autobrr filter
+
+By setting `matchRelease: true` in your config, it will use the `Match releases` field in your autobrr filter instead of fields like `Movies / Shows` and `Albums`.
+
+Readarr will only use the `Match releases` field for now, so setting `matchRelease: false` for Readarr will be ignored.
 
 ## Commands
 

--- a/config.yml
+++ b/config.yml
@@ -15,12 +15,16 @@ clients:
       apikey: API_KEY
       filters:
         - 15
+      #matchRelease: false / true
+
     - name: radarr4k
       type: radarr
       host: http://localhost:7878
       apikey: API_KEY
       filters:
         - 16
+      #matchRelease: false / true
+
     - name: sonarr
       type: sonarr
       host: http://localhost:8989
@@ -31,3 +35,20 @@ clients:
         - mytag
       tagsExclude:
         - myothertag
+      #matchRelease: false / true
+
+    - name: lidarr
+      type: lidarr
+      host: http://localhost:8686
+      apikey: API_KEY
+      filters:
+        - 13
+      #matchRelease: false / true
+
+    - name: readarr
+      type: readarr
+      host: http://localhost:8787
+      apikey: API_KEY
+      filters:
+        - 12
+      #matchRelease: false # will not use other fields yet, so not needed.

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -21,14 +21,15 @@ type BasicAuth struct {
 }
 
 type ArrConfig struct {
-	Name        string     `koanf:"name"`
-	Type        ArrType    `koanf:"type"`
-	Host        string     `koanf:"host"`
-	Apikey      string     `koanf:"apikey"`
-	BasicAuth   *BasicAuth `koanf:"basicAuth"`
-	Filters     []int      `koanf:"filters"`
-	TagsInclude []string   `koanf:"tagsInclude"`
-	TagsExclude []string   `koanf:"tagsExclude"`
+	Name         string     `koanf:"name"`
+	Type         ArrType    `koanf:"type"`
+	Host         string     `koanf:"host"`
+	Apikey       string     `koanf:"apikey"`
+	BasicAuth    *BasicAuth `koanf:"basicAuth"`
+	Filters      []int      `koanf:"filters"`
+	TagsInclude  []string   `koanf:"tagsInclude"`
+	TagsExclude  []string   `koanf:"tagsExclude"`
+	MatchRelease bool       `koanf:"matchRelease"`
 }
 
 type ArrType string

--- a/internal/processor/lidarr.go
+++ b/internal/processor/lidarr.go
@@ -38,27 +38,20 @@ func (s Service) lidarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 		l.Debug().Msgf("updating filter: %v", filterID)
 
-		if !cfg.MatchRelease {
-			if !dryRun {
-				f := autobrr.UpdateFilter{Albums: joinedTitles}
+		f := autobrr.UpdateFilter{Albums: joinedTitles}
 
-				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating music filter: %v", filterID)
-					continue
-				}
-			}
+		if cfg.MatchRelease {
+			f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
+		}
 
-			l.Debug().Msgf("successfully updated filter: %v", filterID)
-		} else {
-			if !dryRun {
-				f := autobrr.UpdateFilter{MatchReleases: joinedTitles}
-
-				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating music filter: %v", filterID)
-					continue
-				}
+		if !dryRun {
+			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+				l.Error().Err(err).Msgf("something went wrong updating music filter: %v", filterID)
+				continue
 			}
 		}
+
+		l.Debug().Msgf("successfully updated filter: %v", filterID)
 
 	}
 

--- a/internal/processor/lidarr.go
+++ b/internal/processor/lidarr.go
@@ -125,7 +125,7 @@ func (s Service) processLidarr(ctx context.Context, cfg *domain.ArrConfig, logge
 		//titles = append(titles, rls.MustNormalize(m.OriginalTitle))
 		//titles = append(titles, rls.MustClean(m.Title))
 
-		titles = append(titles, processTitle(m.Title, cfg)...)
+		titles = append(titles, processTitle(m.Title, cfg.MatchRelease)...)
 
 		//	titles = append(titles, processTitle(m.OriginalTitle)...)
 

--- a/internal/processor/radarr.go
+++ b/internal/processor/radarr.go
@@ -38,27 +38,20 @@ func (s Service) radarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 		l.Debug().Msgf("updating filter: %v", filterID)
 
-		if !cfg.MatchRelease {
-			if !dryRun {
-				f := autobrr.UpdateFilter{Shows: joinedTitles}
+		f := autobrr.UpdateFilter{Shows: joinedTitles}
 
-				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating movie filter: %v", filterID)
-					continue
-				}
-			}
+		if cfg.MatchRelease {
+			f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
+		}
 
-			l.Debug().Msgf("successfully updated filter: %v", filterID)
-		} else {
-			if !dryRun {
-				f := autobrr.UpdateFilter{MatchReleases: joinedTitles}
-
-				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating movie filter: %v", filterID)
-					continue
-				}
+		if !dryRun {
+			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+				l.Error().Err(err).Msgf("something went wrong updating movie filter: %v", filterID)
+				continue
 			}
 		}
+
+		l.Debug().Msgf("successfully updated filter: %v", filterID)
 
 	}
 

--- a/internal/processor/radarr.go
+++ b/internal/processor/radarr.go
@@ -125,11 +125,11 @@ func (s Service) processRadarr(ctx context.Context, cfg *domain.ArrConfig, logge
 		ot := strings.ToLower(m.OriginalTitle)
 
 		if t == ot {
-			titles = append(titles, processTitle(m.Title, cfg)...)
+			titles = append(titles, processTitle(m.Title, cfg.MatchRelease)...)
 			continue
 		}
 
-		titles = append(titles, processTitle(m.OriginalTitle, cfg)...)
+		titles = append(titles, processTitle(m.Title, cfg.MatchRelease)...)
 
 		//for _, title := range m.AlternateTitles {
 		//	titles = append(titles, processTitle(title.Title)...)

--- a/internal/processor/radarr.go
+++ b/internal/processor/radarr.go
@@ -129,7 +129,7 @@ func (s Service) processRadarr(ctx context.Context, cfg *domain.ArrConfig, logge
 			continue
 		}
 
-		titles = append(titles, processTitle(m.Title, cfg.MatchRelease)...)
+		titles = append(titles, processTitle(m.OriginalTitle, cfg.MatchRelease)...)
 
 		//for _, title := range m.AlternateTitles {
 		//	titles = append(titles, processTitle(title.Title)...)

--- a/internal/processor/readarr.go
+++ b/internal/processor/readarr.go
@@ -120,7 +120,7 @@ func (s Service) processReadarr(ctx context.Context, cfg *domain.ArrConfig, logg
 		//titles = append(titles, rls.MustNormalize(m.OriginalTitle))
 		//titles = append(titles, rls.MustClean(m.Title))
 
-		titles = append(titles, processTitle(m.Title, cfg)...)
+		titles = append(titles, processTitle(m.Title, cfg.MatchRelease)...)
 
 		//	titles = append(titles, processTitle(m.OriginalTitle)...)
 

--- a/internal/processor/readarr.go
+++ b/internal/processor/readarr.go
@@ -120,7 +120,7 @@ func (s Service) processReadarr(ctx context.Context, cfg *domain.ArrConfig, logg
 		//titles = append(titles, rls.MustNormalize(m.OriginalTitle))
 		//titles = append(titles, rls.MustClean(m.Title))
 
-		titles = append(titles, processTitle(m.Title)...)
+		titles = append(titles, processTitle(m.Title, cfg)...)
 
 		//	titles = append(titles, processTitle(m.OriginalTitle)...)
 

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -38,29 +38,20 @@ func (s Service) sonarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 		l.Debug().Msgf("updating filter: %v", filterID)
 
-		if !cfg.MatchRelease {
+		f := autobrr.UpdateFilter{Shows: joinedTitles}
 
-			if !dryRun {
-				f := autobrr.UpdateFilter{Shows: joinedTitles}
-
-				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
-					continue
-				}
-			}
-
-			l.Debug().Msgf("successfully updated filter: %v", filterID)
-		} else {
-			if !dryRun {
-				f := autobrr.UpdateFilter{MatchReleases: joinedTitles}
-
-				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
-					continue
-				}
-			}
-			l.Debug().Msgf("successfully updated filter: %v", filterID)
+		if cfg.MatchRelease {
+			f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
 		}
+
+		if !dryRun {
+			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+				l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+				continue
+			}
+		}
+
+		l.Debug().Msgf("successfully updated filter: %v", filterID)
 
 	}
 

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -38,16 +38,30 @@ func (s Service) sonarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 		l.Debug().Msgf("updating filter: %v", filterID)
 
-		if !dryRun {
-			f := autobrr.UpdateFilter{MatchReleases: joinedTitles}
+		if !cfg.MatchRelease {
 
-			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-				l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
-				continue
+			if !dryRun {
+				f := autobrr.UpdateFilter{Shows: joinedTitles}
+
+				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					continue
+				}
 			}
+
+			l.Debug().Msgf("successfully updated filter: %v", filterID)
+		} else {
+			if !dryRun {
+				f := autobrr.UpdateFilter{MatchReleases: joinedTitles}
+
+				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					continue
+				}
+			}
+			l.Debug().Msgf("successfully updated filter: %v", filterID)
 		}
 
-		l.Debug().Msgf("successfully updated filter: %v", filterID)
 	}
 
 	return nil
@@ -115,7 +129,7 @@ func (s Service) processSonarr(ctx context.Context, cfg *domain.ArrConfig, logge
 		//titles = append(titles, rls.MustNormalize(s.Title))
 		//titles = append(titles, rls.MustClean(s.Title))
 
-		titles = append(titles, processTitle(s.Title)...)
+		titles = append(titles, processTitle(s.Title, cfg)...)
 
 		//for _, title := range s.AlternateTitles {
 		//	titles = append(titles, processTitle(title.Title)...)

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -120,7 +120,7 @@ func (s Service) processSonarr(ctx context.Context, cfg *domain.ArrConfig, logge
 		//titles = append(titles, rls.MustNormalize(s.Title))
 		//titles = append(titles, rls.MustClean(s.Title))
 
-		titles = append(titles, processTitle(s.Title, cfg)...)
+		titles = append(titles, processTitle(s.Title, cfg.MatchRelease)...)
 
 		//for _, title := range s.AlternateTitles {
 		//	titles = append(titles, processTitle(title.Title)...)

--- a/internal/processor/title.go
+++ b/internal/processor/title.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/autobrr/omegabrr/internal/domain"
 )
 
-func processTitle(title string) []string {
+func processTitle(title string, cfg *domain.ArrConfig) []string {
 	// replace - : _
 	if title == "" || title == " " {
 		return nil
@@ -19,35 +21,35 @@ func processTitle(title string) []string {
 	t := NewTitleSlice()
 
 	//titles = append(titles, rls.MustNormalize(title))
-	t.Add(strings.ReplaceAll(title, " ", "?"))
+	t.Add(strings.ReplaceAll(title, " ", "?"), cfg)
 
 	//fmt.Println(rls.MustClean(title))
 	//fmt.Println(rls.MustNormalize(title))
 
 	if strings.Contains(title, ". ") {
-		t.Add(strings.ReplaceAll(title, ". ", "??"))
+		t.Add(strings.ReplaceAll(title, ". ", "??"), cfg)
 
 		strip := strings.ReplaceAll(title, ". ", " ")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace)
+		t.Add(replace, cfg)
 	}
 
 	if strings.ContainsAny(title, "-") {
 		strip := strings.ReplaceAll(title, "-", "?")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace)
+		t.Add(replace, cfg)
 	}
 
 	if strings.ContainsAny(title, "!") {
 		strip := strings.ReplaceAll(title, "!", "?")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace)
+		t.Add(replace, cfg)
 	}
 
 	if strings.ContainsAny(title, ":") {
 		strip := strings.ReplaceAll(title, ":", "")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace)
+		t.Add(replace, cfg)
 
 		split := strings.Split(title, ":")
 		if len(split) > 1 {
@@ -55,17 +57,17 @@ func processTitle(title string) []string {
 			second := strings.ReplaceAll(strings.Trim(split[1], " "), " ", "?")
 			part := fmt.Sprintf("%v*%v", first, second)
 
-			t.Add(part)
+			t.Add(part, cfg)
 		}
 
 	}
 
 	if strings.ContainsAny(title, "&") {
-		t.Add(strings.ReplaceAll(title, " ", "?"))
+		t.Add(strings.ReplaceAll(title, " ", "?"), cfg)
 
 		strip := strings.ReplaceAll(title, "&", "and")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace)
+		t.Add(replace, cfg)
 	}
 
 	return t.Titles()
@@ -82,8 +84,11 @@ func NewTitleSlice() *Titles {
 	return &ts
 }
 
-func (ts *Titles) Add(title string) {
-	title = fmt.Sprintf("*%v*", title)
+func (ts *Titles) Add(title string, cfg *domain.ArrConfig) {
+	if cfg.MatchRelease {
+		title = fmt.Sprintf("*%v*", title)
+	}
+
 	_, ok := ts.tm[title]
 	if !ok {
 		ts.tm[title] = struct{}{}

--- a/internal/processor/title.go
+++ b/internal/processor/title.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/autobrr/omegabrr/internal/domain"
 )
 
-func processTitle(title string, cfg *domain.ArrConfig) []string {
+func processTitle(title string, matchRelease bool) []string {
 	// replace - : _
 	if title == "" || title == " " {
 		return nil
@@ -21,35 +19,35 @@ func processTitle(title string, cfg *domain.ArrConfig) []string {
 	t := NewTitleSlice()
 
 	//titles = append(titles, rls.MustNormalize(title))
-	t.Add(strings.ReplaceAll(title, " ", "?"), cfg)
+	t.Add(strings.ReplaceAll(title, " ", "?"), matchRelease)
 
 	//fmt.Println(rls.MustClean(title))
 	//fmt.Println(rls.MustNormalize(title))
 
 	if strings.Contains(title, ". ") {
-		t.Add(strings.ReplaceAll(title, ". ", "??"), cfg)
+		t.Add(strings.ReplaceAll(title, ". ", "??"), matchRelease)
 
 		strip := strings.ReplaceAll(title, ". ", " ")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace, cfg)
+		t.Add(replace, matchRelease)
 	}
 
 	if strings.ContainsAny(title, "-") {
 		strip := strings.ReplaceAll(title, "-", "?")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace, cfg)
+		t.Add(replace, matchRelease)
 	}
 
 	if strings.ContainsAny(title, "!") {
 		strip := strings.ReplaceAll(title, "!", "?")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace, cfg)
+		t.Add(replace, matchRelease)
 	}
 
 	if strings.ContainsAny(title, ":") {
 		strip := strings.ReplaceAll(title, ":", "")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace, cfg)
+		t.Add(replace, matchRelease)
 
 		split := strings.Split(title, ":")
 		if len(split) > 1 {
@@ -57,17 +55,17 @@ func processTitle(title string, cfg *domain.ArrConfig) []string {
 			second := strings.ReplaceAll(strings.Trim(split[1], " "), " ", "?")
 			part := fmt.Sprintf("%v*%v", first, second)
 
-			t.Add(part, cfg)
+			t.Add(part, matchRelease)
 		}
 
 	}
 
 	if strings.ContainsAny(title, "&") {
-		t.Add(strings.ReplaceAll(title, " ", "?"), cfg)
+		t.Add(strings.ReplaceAll(title, " ", "?"), matchRelease)
 
 		strip := strings.ReplaceAll(title, "&", "and")
 		replace := strings.ReplaceAll(strip, " ", "?")
-		t.Add(replace, cfg)
+		t.Add(replace, matchRelease)
 	}
 
 	return t.Titles()
@@ -84,8 +82,8 @@ func NewTitleSlice() *Titles {
 	return &ts
 }
 
-func (ts *Titles) Add(title string, cfg *domain.ArrConfig) {
-	if cfg.MatchRelease {
+func (ts *Titles) Add(title string, matchRelease bool) {
+	if matchRelease {
 		title = fmt.Sprintf("*%v*", title)
 	}
 

--- a/pkg/autobrr/client.go
+++ b/pkg/autobrr/client.go
@@ -144,5 +144,7 @@ type Filter struct {
 }
 
 type UpdateFilter struct {
+	Shows         string `json:"shows"`
+	Albums        string `json:"albums"`
 	MatchReleases string `json:"match_releases"`
 }


### PR DESCRIPTION
If you want to use the `Match releases` field instead, then call it with `matchRelease: true` in config.
Readarr will only use the `Match releases` field and will ignore any other options.

Closes #13 