### PR TITLE
feat: Optionally not overwrite data in Match Releases when using Movies / Shows or Albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ By setting `matchRelease: true` in your config, it will use the `Match releases`
 
 Readarr will only use the `Match releases` field for now, so setting `matchRelease: false` for Readarr will be ignored.
 
+## Don't clear the Match Releases field when using the `Movies / Shows` and `Albums` fields
+
+By setting `keepReleaseData: true` in your config, it will not clear the Match Releases field whenever omegabrr updates the filters. This can be useful if you want additional filtering, while still having the *arrs occupy the `Movies / Shows` or `Albums` fields.
+
 ## Commands
 
 Available commands.

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -21,15 +21,16 @@ type BasicAuth struct {
 }
 
 type ArrConfig struct {
-	Name         string     `koanf:"name"`
-	Type         ArrType    `koanf:"type"`
-	Host         string     `koanf:"host"`
-	Apikey       string     `koanf:"apikey"`
-	BasicAuth    *BasicAuth `koanf:"basicAuth"`
-	Filters      []int      `koanf:"filters"`
-	TagsInclude  []string   `koanf:"tagsInclude"`
-	TagsExclude  []string   `koanf:"tagsExclude"`
-	MatchRelease bool       `koanf:"matchRelease"`
+	Name            string     `koanf:"name"`
+	Type            ArrType    `koanf:"type"`
+	Host            string     `koanf:"host"`
+	Apikey          string     `koanf:"apikey"`
+	BasicAuth       *BasicAuth `koanf:"basicAuth"`
+	Filters         []int      `koanf:"filters"`
+	TagsInclude     []string   `koanf:"tagsInclude"`
+	TagsExclude     []string   `koanf:"tagsExclude"`
+	MatchRelease    bool       `koanf:"matchRelease"`
+	KeepReleaseData bool       `koanf:"keepReleaseData"`
 }
 
 type ArrType string

--- a/internal/processor/lidarr.go
+++ b/internal/processor/lidarr.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s Service) lidarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool, brr *autobrr.Client) error {
-	l := log.With().Str("type", "sonarr").Str("client", cfg.Name).Logger()
+	l := log.With().Str("type", "lidarr").Str("client", cfg.Name).Logger()
 
 	l.Debug().Msgf("gathering titles...")
 

--- a/internal/processor/lidarr.go
+++ b/internal/processor/lidarr.go
@@ -46,7 +46,7 @@ func (s Service) lidarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 			if !dryRun {
 				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					l.Error().Err(err).Msgf("something went wrong updating music filter: %v", filterID)
 					continue
 				}
 			}
@@ -56,7 +56,7 @@ func (s Service) lidarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 			if !dryRun {
 				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					l.Error().Err(err).Msgf("something went wrong updating music filter: %v", filterID)
 					continue
 				}
 			}
@@ -65,7 +65,7 @@ func (s Service) lidarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 			if !dryRun {
 				if err := brr.UpdateFilterSpecial(ctx, filterID, s); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					l.Error().Err(err).Msgf("something went wrong updating music filter: %v", filterID)
 					continue
 				}
 			}

--- a/internal/processor/radarr.go
+++ b/internal/processor/radarr.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s Service) radarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool, brr *autobrr.Client) error {
-	l := log.With().Str("type", "sonarr").Str("client", cfg.Name).Logger()
+	l := log.With().Str("type", "radarr").Str("client", cfg.Name).Logger()
 
 	l.Debug().Msgf("gathering titles...")
 

--- a/internal/processor/radarr.go
+++ b/internal/processor/radarr.go
@@ -46,7 +46,7 @@ func (s Service) radarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 			if !dryRun {
 				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					l.Error().Err(err).Msgf("something went wrong updating movie filter: %v", filterID)
 					continue
 				}
 			}
@@ -56,7 +56,7 @@ func (s Service) radarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 			if !dryRun {
 				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					l.Error().Err(err).Msgf("something went wrong updating movie filter: %v", filterID)
 					continue
 				}
 			}
@@ -65,7 +65,7 @@ func (s Service) radarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 			if !dryRun {
 				if err := brr.UpdateFilterSpecial(ctx, filterID, s); err != nil {
-					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					l.Error().Err(err).Msgf("something went wrong updating movie filter: %v", filterID)
 					continue
 				}
 			}

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -42,7 +42,7 @@ func (s Service) sonarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 		s := autobrr.UpdateFilterSpecial{Shows: joinedTitles}
 
 		if cfg.MatchRelease {
-			s = autobrr.UpdateFilterSpecial{Shows: joinedTitles}
+			f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
 		}
 
 		if cfg.KeepReleaseData {

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -43,19 +43,31 @@ func (s Service) sonarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 		if cfg.MatchRelease {
 			f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
-		}
 
-		if cfg.KeepReleaseData {
+			if !dryRun {
+				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					continue
+				}
+			}
+
+		} else if !cfg.KeepReleaseData {
+			f = autobrr.UpdateFilter{Shows: joinedTitles}
+
+			if !dryRun {
+				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					continue
+				}
+			}
+		} else if cfg.KeepReleaseData && !cfg.MatchRelease {
+			s = autobrr.UpdateFilterSpecial{Shows: joinedTitles}
+
 			if !dryRun {
 				if err := brr.UpdateFilterSpecial(ctx, filterID, s); err != nil {
 					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
 					continue
 				}
-			}
-		} else if !dryRun {
-			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-				l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
-				continue
 			}
 		}
 

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -52,9 +52,7 @@ func (s Service) sonarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 					continue
 				}
 			}
-		}
-
-		if !dryRun {
+		} else if !dryRun {
 			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
 				l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
 				continue

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -39,9 +39,19 @@ func (s Service) sonarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 		l.Debug().Msgf("updating filter: %v", filterID)
 
 		f := autobrr.UpdateFilter{Shows: joinedTitles}
+		s := autobrr.UpdateFilterSpecial{Shows: joinedTitles}
 
 		if cfg.MatchRelease {
-			f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
+			s = autobrr.UpdateFilterSpecial{Shows: joinedTitles}
+		}
+
+		if cfg.KeepReleaseData {
+			if !dryRun {
+				if err := brr.UpdateFilterSpecial(ctx, filterID, s); err != nil {
+					l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
+					continue
+				}
+			}
 		}
 
 		if !dryRun {

--- a/pkg/autobrr/client.go
+++ b/pkg/autobrr/client.go
@@ -136,6 +136,43 @@ func (c *Client) UpdateFilterByID(ctx context.Context, filterID int, filter Upda
 	return nil
 }
 
+func (c *Client) UpdateFilterSpecial(ctx context.Context, filterID int, filter UpdateFilterSpecial) error {
+	id := strconv.Itoa(filterID)
+
+	body, err := json.Marshal(filter)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.Host+"/api/filters/"+id, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+
+	req.SetBasicAuth(c.BasicUser, c.BasicPass)
+	req.Header.Add("X-API-Token", c.APIKey)
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	dump, err := httputil.DumpResponse(res, true)
+	if err != nil {
+		return errors.Wrap(err, "could not dump response")
+	}
+
+	log.Trace().Msgf("update filter response: %v", string(dump))
+
+	if res.StatusCode != http.StatusNoContent {
+		return errors.New("bad status")
+	}
+
+	return nil
+}
+
+
 type Filter struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
@@ -147,4 +184,10 @@ type UpdateFilter struct {
 	Shows         string `json:"shows"`
 	Albums        string `json:"albums"`
 	MatchReleases string `json:"match_releases"`
+}
+
+type UpdateFilterSpecial struct {
+	Shows         string `json:"shows"`
+	Albums        string `json:"albums"`
+	MatchReleases string `json:"match_releases,omitempty"`
 }

--- a/pkg/autobrr/client.go
+++ b/pkg/autobrr/client.go
@@ -172,7 +172,6 @@ func (c *Client) UpdateFilterSpecial(ctx context.Context, filterID int, filter U
 	return nil
 }
 
-
 type Filter struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`


### PR DESCRIPTION
Added a config variable to not clear the `Match Releases` field when `matchRelease` is false or unset.

Why? So you can use the `Match Releases` field for additional filtering while the `Movies / Shows` or `Albums` fields are used for titles.

Can be called in the config with:
`keepReleaseData: true`

Resolves #27 