### PR TITLE
feat: Do not clear match_releases when using shows

### DIFF
--- a/pkg/autobrr/client.go
+++ b/pkg/autobrr/client.go
@@ -146,5 +146,5 @@ type Filter struct {
 type UpdateFilter struct {
 	Shows         string `json:"shows"`
 	Albums        string `json:"albums"`
-	MatchReleases string `json:"match_releases"`
+	MatchReleases string `json:"match_releases,omitempty"`
 }


### PR DESCRIPTION
Leave match_releases field untouched when using shows.
Replacing #28 as a more simpler solution.


Resolves #27 