### PR TITLE
feat(arr): add Whisparr

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ clients:
       apikey: YOUR_API_KEY
       filters:
         - 12
+
+    - name: whisparr
+      type: whisparr
+      host: https://yourdomain.com/whisparr
+      apikey: YOUR_API_KEY
+      filters:
+        - 69
+      #matchRelease: false / true
 ```
 
 If you're trying to reach radarr or sonarr hosted on swizzin from some other location, you need to do it like this with basic auth:

--- a/config.yml
+++ b/config.yml
@@ -52,3 +52,11 @@ clients:
       filters:
         - 12
       #matchRelease: false # will not use other fields yet, so not needed.
+
+    - name: whisparr
+      type: whisparr
+      host: http://localhost:6969
+      apikey: API_KEY
+      filters:
+        - 69
+      #matchRelease: false / true

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -35,10 +35,11 @@ type ArrConfig struct {
 type ArrType string
 
 var (
-	ArrTypeRadarr  ArrType = "radarr"
-	ArrTypeSonarr  ArrType = "sonarr"
-	ArrTypeReadarr ArrType = "readarr"
-	ArrTypeLidarr  ArrType = "lidarr"
+	ArrTypeRadarr   ArrType = "radarr"
+	ArrTypeSonarr   ArrType = "sonarr"
+	ArrTypeReadarr  ArrType = "readarr"
+	ArrTypeLidarr   ArrType = "lidarr"
+	ArrTypeWhisparr ArrType = "whisparr"
 )
 
 type AutobrrConfig struct {
@@ -201,4 +202,11 @@ clients:
   #   host: http://localhost:8686
   #   apikey: API_KEY
   #   filters:
-  #     - 32 # Change me`
+  #     - 32 # Change me
+
+  # - name: whisparr
+  #   type: whisparr
+  #   host: http://localhost:6969
+  #   apikey: API_KEY
+  #   filters:
+  #     - 69 # Change me`

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -50,6 +50,11 @@ func (s Service) Process(dryRun bool) error {
 					return s.radarr(ctx, arrClient, dryRun, a)
 				})
 
+			case domain.ArrTypeWhisparr:
+				g.Go(func() error {
+					return s.radarr(ctx, arrClient, dryRun, a)
+				})
+
 			case domain.ArrTypeSonarr:
 				g.Go(func() error {
 					return s.sonarr(ctx, arrClient, dryRun, a)


### PR DESCRIPTION
Added Whisparr support using the golift.io/starr/radarr library
Tested and working as expected 🍆

It'll show up as `client=whisparr type=radarr` in the log output since we're basically using `radarr.go` for this, but the user sets `type: whisparr` in their config.

```
2023-02-03T19:11:02+01:00 DBG starting filter processing...
2023-02-03T19:11:02+01:00 DBG gathering titles... client=whisparr type=radarr
2023-02-03T19:11:02+01:00 DBG found 2 movies to process client=whisparr type=radarr
2023-02-03T19:11:02+01:00 DBG from a total of 2 movies we found 2 monitored and created 2 release titles client=whisparr type=radarr
2023-02-03T19:11:02+01:00 DBG got 2 filter titles client=whisparr type=radarr
2023-02-03T19:11:02+01:00 TRC Naughty?Movie,Kyles?Forgotten?Tapes client=whisparr type=radarr
2023-02-03T19:11:02+01:00 DBG updating filter: 13 client=whisparr type=radarr
```