### PR TITLE
feat(sonarr): Include alternate titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ clients:
       filters:
         - 14
       #matchRelease: false / true
+      #excludeAlternateTitles: false/ true # only works for Sonarr and defaults to false
 
     - name: lidarr
       type: lidarr
@@ -117,6 +118,10 @@ If you want to exclude certain tags, you can use the `tagsExclude`.
 By setting `matchRelease: true` in your config, it will use the `Match releases` field in your autobrr filter instead of fields like `Movies / Shows` and `Albums`.
 
 Readarr will only use the `Match releases` field for now, so setting `matchRelease: false` for Readarr will be ignored.
+
+## Exclude alternative titles from Sonarr
+
+You can drop alternate show titles from being added by setting `excludeAlternateTitles: true` for Sonarr in your config.
 
 ## Commands
 

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -21,15 +21,16 @@ type BasicAuth struct {
 }
 
 type ArrConfig struct {
-	Name         string     `koanf:"name"`
-	Type         ArrType    `koanf:"type"`
-	Host         string     `koanf:"host"`
-	Apikey       string     `koanf:"apikey"`
-	BasicAuth    *BasicAuth `koanf:"basicAuth"`
-	Filters      []int      `koanf:"filters"`
-	TagsInclude  []string   `koanf:"tagsInclude"`
-	TagsExclude  []string   `koanf:"tagsExclude"`
-	MatchRelease bool       `koanf:"matchRelease"`
+	Name                   string     `koanf:"name"`
+	Type                   ArrType    `koanf:"type"`
+	Host                   string     `koanf:"host"`
+	Apikey                 string     `koanf:"apikey"`
+	BasicAuth              *BasicAuth `koanf:"basicAuth"`
+	Filters                []int      `koanf:"filters"`
+	TagsInclude            []string   `koanf:"tagsInclude"`
+	TagsExclude            []string   `koanf:"tagsExclude"`
+	MatchRelease           bool       `koanf:"matchRelease"`
+	ExcludeAlternateTitles bool       `koanf:"excludeAlternateTitles"`
 }
 
 type ArrType string

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -189,6 +189,7 @@ clients:
   #    apikey: API_KEY
   #    filters:
   #      - 14 # Change me
+  #    #excludeAlternateTitles: true # defaults to false
 	
   #  - name: readarr
   #    type: readarr

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -122,9 +122,11 @@ func (s Service) processSonarr(ctx context.Context, cfg *domain.ArrConfig, logge
 
 		titles = append(titles, processTitle(s.Title, cfg.MatchRelease)...)
 
-		//for _, title := range s.AlternateTitles {
-		//	titles = append(titles, processTitle(title.Title)...)
-		//}
+		if !cfg.ExcludeAlternateTitles {
+			for _, title := range s.AlternateTitles {
+				titles = append(titles, processTitle(title.Title, cfg.MatchRelease)...)
+			}
+		}
 	}
 
 	logger.Debug().Msgf("from a total of %d shows we found %d monitored and created %d release titles", len(shows), monitoredTitles, len(titles))


### PR DESCRIPTION
This is great for whenever a show is released under its original title. This happens a lot for foreign shows.

Alternate titles can be excluded with`excludeAlternateTitles: true` in the config.