### PR TITLE
enhancement(log): Output reason for config errors

### DIFF
--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 	"text/template"
-	"log"
 
 	"github.com/autobrr/omegabrr/internal/apitoken"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 type BasicAuth struct {
@@ -83,17 +83,26 @@ func NewConfig(configPath string) *Config {
 		// create config if it doesn't exist
 		if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
 			if writeErr := cfg.writeFile(configPath); writeErr != nil {
-				log.Fatal()
+				log.Fatal().
+					Err(writeErr).
+					Str("service", "config").
+					Msgf("failed writing %q", configPath)
 			}
 		}
 
 		if err := k.Load(file.Provider(configPath), yaml.Parser()); err != nil {
-			log.Fatalf("error loading config: %v", err)
+			log.Fatal().
+				Err(err).
+				Str("service", "config").
+				Msgf("failed parsing %q", configPath)
 		}
 
 		// unmarshal
 		if err := k.Unmarshal("", &cfg); err != nil {
-			log.Fatal()
+			log.Fatal().
+				Err(err).
+				Str("service", "config").
+				Msgf("failed unmarshalling %q", configPath)
 		}
 	}
 

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"text/template"
+	"log"
 
 	"github.com/autobrr/omegabrr/internal/apitoken"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 )
 
 type BasicAuth struct {
@@ -88,7 +88,7 @@ func NewConfig(configPath string) *Config {
 		}
 
 		if err := k.Load(file.Provider(configPath), yaml.Parser()); err != nil {
-			log.Fatal()
+			log.Fatalf("error loading config: %v", err)
 		}
 
 		// unmarshal


### PR DESCRIPTION
Minor change to make the error message make sense if the config has errors in it.

~~Had to replace zerolog with log to make this work. Maybe you have a better idea @zze0s? I guess there is a reason you use zerolog over log.~~

Example if the config has tabs or bad indentation it now shows this:
```
./omegabrr arr --config config.yaml
2023-02-14T09:25:55+01:00 FTL failed parsing "config.yaml" error="yaml: line 24: found a tab character that violates indentation" service=config
```

```
./omegabrr arr --config config.yaml
2023-02-14T09:25:14+01:00 FTL failed parsing "config.yaml" error="yaml: line 18: did not find expected '-' indicator" service=config
```
Thanks @KyleSanderson for the assist