### PR TITLE
feat(radarr): Add both OriginalTitle and Title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.dist
 dist
 .dev
+.DS_Store
 
 # Binaries for programs and plugins
 *.exe

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/stretchr/testify v1.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/internal/processor/radarr.go
+++ b/internal/processor/radarr.go
@@ -117,23 +117,18 @@ func (s Service) processRadarr(ctx context.Context, cfg *domain.ArrConfig, logge
 		// increment monitored titles
 		monitoredTitles++
 
-		//titles = append(titles, rls.MustNormalize(m.Title))
-		//titles = append(titles, rls.MustNormalize(m.OriginalTitle))
-		//titles = append(titles, rls.MustClean(m.Title))
+		// Taking the english title and the original title and appending them to the titles array.
+		titlesMap := make(map[string]bool) // Initialize a map to keep track of unique titles.
+		t := m.Title
+		ot := m.OriginalTitle
 
-		t := strings.ToLower(m.Title)
-		ot := strings.ToLower(m.OriginalTitle)
-
-		if t == ot {
-			titles = append(titles, processTitle(m.Title, cfg.MatchRelease)...)
-			continue
+		for _, title := range []string{t, ot} {
+			if title != "" && !titlesMap[title] {
+				titlesMap[title] = true
+				titles = append(titles, processTitle(title, cfg.MatchRelease)...)
+			}
 		}
 
-		titles = append(titles, processTitle(m.OriginalTitle, cfg.MatchRelease)...)
-
-		//for _, title := range m.AlternateTitles {
-		//	titles = append(titles, processTitle(title.Title)...)
-		//}
 	}
 
 	logger.Debug().Msgf("from a total of %d movies we found %d monitored and created %d release titles", len(movies), monitoredTitles, len(titles))

--- a/internal/processor/radarr.go
+++ b/internal/processor/radarr.go
@@ -117,7 +117,7 @@ func (s Service) processRadarr(ctx context.Context, cfg *domain.ArrConfig, logge
 		// increment monitored titles
 		monitoredTitles++
 
-		// Taking the english title and the original title and appending them to the titles array.
+		// Taking the international title and the original title and appending them to the titles array.
 		titlesMap := make(map[string]bool) // Initialize a map to keep track of unique titles.
 		t := m.Title
 		ot := m.OriginalTitle


### PR DESCRIPTION
The current implementation only adds the original title to the titles array, but this PR adds the international title as well. This change offers the following benefits:

With both titles added to the array, autobrr can match and push to Radarr using either title, increasing the likelihood of a successful match.
Different release groups may use either the original or international title, with some high-quality groups preferring the latter. By adding both titles to the array, autobrr can ensure it matches the next available release, regardless of the title used.
There are no apparent drawbacks to this change, as it simply expands the range of possible titles and improves the matching and upgrade process.