### PR TITLE
fix(tags): exclude non-specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/stretchr/testify v1.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/internal/processor/radarr.go
+++ b/internal/processor/radarr.go
@@ -100,9 +100,6 @@ func (s Service) processRadarr(ctx context.Context, cfg *domain.ArrConfig, logge
 		}
 
 		if len(cfg.TagsInclude) > 0 {
-			if len(m.Tags) == 0 {
-				continue
-			}
 			if !containsTag(tags, m.Tags, cfg.TagsInclude) {
 				continue
 			}

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -100,9 +100,6 @@ func (s Service) processSonarr(ctx context.Context, cfg *domain.ArrConfig, logge
 		}
 
 		if len(cfg.TagsInclude) > 0 {
-			if len(s.Tags) == 0 {
-				continue
-			}
 			if !containsTag(tags, s.Tags, cfg.TagsInclude) {
 				continue
 			}

--- a/internal/processor/tags.go
+++ b/internal/processor/tags.go
@@ -17,6 +17,9 @@ func containsTag(tags []*starr.Tag, titleTags []int, checkTags []string) bool {
 		}
 	}
 
+	// log the tagLabels and checkTags
+	//log.Printf("tagLabels: %v, checkTags: %v", tagLabels, checkTags)
+
 	// check included tags and set ret to true if we have a match
 	for _, includeTag := range checkTags {
 		for _, label := range tagLabels {

--- a/internal/processor/tags.go
+++ b/internal/processor/tags.go
@@ -17,9 +17,6 @@ func containsTag(tags []*starr.Tag, titleTags []int, checkTags []string) bool {
 		}
 	}
 
-	// log the tagLabels and checkTags
-	//log.Printf("tagLabels: %v, checkTags: %v", tagLabels, checkTags)
-
 	// check included tags and set ret to true if we have a match
 	for _, includeTag := range checkTags {
 		for _, label := range tagLabels {


### PR DESCRIPTION
Previously, omegabrr was adding all monitored shows/movies to the list, regardless of whether they had the specified tags in `tagsInclude`. With this PR, omegabrr will now only add shows/movies with the tag(s) specified in `tagsInclude` in config.yaml.

If `tagsInclude` is not used, all monitored shows/movies (except those part of `tagsExclude`) will be added to the list.