### PR TITLE
feat: add lists aka regbrr support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist
 *.so
 *.dylib
 bin
+.vscode/
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -64,52 +64,54 @@ clients:
         - 69 # Change me
       #matchRelease: false / true
 
-  lists:
-    - name: Latest TV Shows
-      type: mdblist
-      url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
-      filters:
-        - 1 # Change me
-    - name: Anticipated TV
-      type: trakt
-      url: https://api.autobrr.com/lists/trakt/anticipated-tv
-      filters:
-        - 22 # Change me
+lists:
+  - name: Latest TV Shows
+    type: mdblist
+    url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
+    filters:
+      - 1 # Change me
 
-    - name: Upcoming Movies
-      type: trakt
-      url: https://api.autobrr.com/lists/trakt/upcoming-movies
-      filters:
-        - 21 # Change me
+  - name: Anticipated TV
+    type: trakt
+    url: https://api.autobrr.com/lists/trakt/anticipated-tv
+    filters:
+      - 22 # Change me
 
-    - name: Upcoming Bluray
-      type: trakt
-      url: https://api.autobrr.com/lists/trakt/upcoming-bluray
-      filters:
-        - 24 # Change me
+  - name: Upcoming Movies
+    type: trakt
+    url: https://api.autobrr.com/lists/trakt/upcoming-movies
+    filters:
+      - 21 # Change me
 
-    - name: Popular TV
-      type: trakt
-      url: https://api.autobrr.com/lists/trakt/popular-tv
-      filters:
-        - 25 # Change me
-    
-    - name: StevenLu
-      type: trakt
-      url: https://api.autobrr.com/lists/stevenlu
-      filters:
-        - 23 # Change me
+  - name: Upcoming Bluray
+    type: trakt
+    url: https://api.autobrr.com/lists/trakt/upcoming-bluray
+    filters:
+      - 24 # Change me
 
-    - name: New Albums
-      type: metacritic
-      url: https://api.autobrr.com/lists/metacritic/new-albums
-      filters:
-        - 9 # Change me
-    - name: Upcoming Albums
-      type: metacritic
-      url: https://api.autobrr.com/lists/metacritic/upcoming-albums
-      filters:
-        - 20 # Change me
+  - name: Popular TV
+    type: trakt
+    url: https://api.autobrr.com/lists/trakt/popular-tv
+    filters:
+      - 25 # Change me
+  
+  - name: StevenLu
+    type: trakt
+    url: https://api.autobrr.com/lists/stevenlu
+    filters:
+      - 23 # Change me
+
+  - name: New Albums
+    type: metacritic
+    url: https://api.autobrr.com/lists/metacritic/new-albums
+    filters:
+      - 9 # Change me
+
+  - name: Upcoming Albums
+    type: metacritic
+    url: https://api.autobrr.com/lists/metacritic/upcoming-albums
+    filters:
+      - 20 # Change me
 ```
 
 If you're trying to reach radarr or sonarr hosted on swizzin from some other location, you need to do it like this with basic auth:
@@ -166,6 +168,25 @@ If you want to exclude certain tags, you can use the `tagsExclude`.
     - 14 # Change me
   tagsExclude:
     - myothertag
+```
+
+### Lists
+
+Formerly known as regbrr and maintained by community members is now integrated into omegabrr! We now maintain the lists of media. 
+
+**Trakt**
+
+If you are using the Trakt api directly you need to have an **API key** which you can set via the headers object along with any other header needed for the request.
+
+```yaml
+lists:
+  - name: Some custom Trakt endpoint
+    type: trakt
+    url: https://api.trakt.tv/calendars/all
+    headers:
+      trakt-api-key: your_key_goes_here
+    filters:
+      - 22 # Change me
 ```
 
 ## Optionally use Match Releases field in your autobrr filter

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ clients:
       host: https://yourdomain.com/radarr
       apikey: YOUR_API_KEY
       filters:
-        - 15
+        - 15 # Change me
       #matchRelease: false / true
 
     - name: sonarr
@@ -37,7 +37,7 @@ clients:
         user: username
         pass: password
       filters:
-        - 14
+        - 14 # Change me
       #matchRelease: false / true
       #excludeAlternateTitles: false/ true # only works for Sonarr and defaults to false
 
@@ -46,7 +46,7 @@ clients:
       host: https://yourdomain.com/lidarr
       apikey: YOUR_API_KEY
       filters:
-        - 13
+        - 13 # Change me
       #matchRelease: false / true
 
     - name: readarr
@@ -54,15 +54,62 @@ clients:
       host: https://yourdomain.com/readarr
       apikey: YOUR_API_KEY
       filters:
-        - 12
+        - 12 # Change me
 
     - name: whisparr
       type: whisparr
       host: https://yourdomain.com/whisparr
       apikey: YOUR_API_KEY
       filters:
-        - 69
+        - 69 # Change me
       #matchRelease: false / true
+
+  lists:
+    - name: Latest TV Shows
+      type: mdblist
+      url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
+      filters:
+        - 1 # Change me
+    - name: Anticipated TV
+      type: trakt
+      url: https://api.autobrr.com/lists/trakt/anticipated-tv
+      filters:
+        - 22 # Change me
+
+    - name: Upcoming Movies
+      type: trakt
+      url: https://api.autobrr.com/lists/trakt/upcoming-movies
+      filters:
+        - 21 # Change me
+
+    - name: Upcoming Bluray
+      type: trakt
+      url: https://api.autobrr.com/lists/trakt/upcoming-bluray
+      filters:
+        - 24 # Change me
+
+    - name: Popular TV
+      type: trakt
+      url: https://api.autobrr.com/lists/trakt/popular-tv
+      filters:
+        - 25 # Change me
+    
+    - name: StevenLu
+      type: trakt
+      url: https://api.autobrr.com/lists/stevenlu
+      filters:
+        - 23 # Change me
+
+    - name: New Albums
+      type: metacritic
+      url: https://api.autobrr.com/lists/metacritic/new-albums
+      filters:
+        - 9 # Change me
+    - name: Upcoming Albums
+      type: metacritic
+      url: https://api.autobrr.com/lists/metacritic/upcoming-albums
+      filters:
+        - 20 # Change me
 ```
 
 If you're trying to reach radarr or sonarr hosted on swizzin from some other location, you need to do it like this with basic auth:
@@ -77,7 +124,7 @@ If you're trying to reach radarr or sonarr hosted on swizzin from some other loc
         user: username
         pass: password
       filters:
-        - 15
+        - 15 # Change me
 ```
 
 Same goes for autobrr if it's behind basic auth.
@@ -103,7 +150,7 @@ If you want to match only certain tags you can use the `tagsInclude`.
   host: http://localhost:8989
   apikey: API_KEY
   filters:
-    - 14
+    - 14 # Change me
   tagsInclude:
     - mytag
 ```
@@ -116,7 +163,7 @@ If you want to exclude certain tags, you can use the `tagsExclude`.
   host: http://localhost:8989
   apikey: API_KEY
   filters:
-    - 14
+    - 14 # Change me
   tagsExclude:
     - myothertag
 ```
@@ -152,6 +199,12 @@ Optionally call with `--length <number>`for a custom length.
 ### arr
 
 Call with `omegabrr arr --config config.yaml`
+
+Supports to run with `--dry-run` to only fetch shows and skip filter update.
+
+### lists
+
+Call with `omegabrr lists --config config.yaml`
 
 Supports to run with `--dry-run` to only fetch shows and skip filter update.
 

--- a/cmd/omegabrr/main.go
+++ b/cmd/omegabrr/main.go
@@ -35,7 +35,8 @@ Usage:
     omegabrr lists              Run omegabrr lists once
     omegabrr run               	Run omegabrr service
     omegabrr version           	Print version info
-    omegabrr help              	Show this help message`
+    omegabrr help              	Show this help message
+` + "\n"
 
 func init() {
 	pflag.Usage = func() {

--- a/cmd/omegabrr/main.go
+++ b/cmd/omegabrr/main.go
@@ -76,6 +76,15 @@ func main() {
 			os.Exit(1)
 		}
 
+	case "lists":
+		cfg := domain.NewConfig(configPath)
+
+		p := processor.NewService(cfg)
+		if err := p.Process(dryRun); err != nil {
+			log.Error().Err(err).Msgf("error during processing")
+			os.Exit(1)
+		}
+
 	case "run":
 		cfg := domain.NewConfig(configPath)
 

--- a/cmd/omegabrr/main.go
+++ b/cmd/omegabrr/main.go
@@ -31,7 +31,8 @@ Turn your monitored shows from your arrs into autobrr filters, automagically!
 
 Usage:
     omegabrr generate-token	Generate API Token	Optionally call with --length <number>
-    omegabrr arr               	Run omegabrr once
+    omegabrr arr               	Run omegabrr arr once
+    omegabrr lists              Run omegabrr lists once
     omegabrr run               	Run omegabrr service
     omegabrr version           	Print version info
     omegabrr help              	Show this help message`

--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,7 @@ clients:
       host: http://localhost:7878
       apikey: API_KEY
       filters:
-        - 15
+        - 15 # Change me
       #matchRelease: false / true
 
     - name: radarr4k
@@ -22,7 +22,7 @@ clients:
       host: http://localhost:7878
       apikey: API_KEY
       filters:
-        - 16
+        - 16 # Change me
       #matchRelease: false / true
 
     - name: sonarr
@@ -30,7 +30,7 @@ clients:
       host: http://localhost:8989
       apikey: API_KEY
       filters:
-        - 14
+        - 14 # Change me
       tagsInclude:
         - mytag
       tagsExclude:
@@ -42,7 +42,7 @@ clients:
       host: http://localhost:8686
       apikey: API_KEY
       filters:
-        - 13
+        - 13 # Change me
       #matchRelease: false / true
 
     - name: readarr
@@ -50,7 +50,7 @@ clients:
       host: http://localhost:8787
       apikey: API_KEY
       filters:
-        - 12
+        - 12 # Change me
       #matchRelease: false # will not use other fields yet, so not needed.
 
     - name: whisparr
@@ -58,5 +58,52 @@ clients:
       host: http://localhost:6969
       apikey: API_KEY
       filters:
-        - 69
+        - 69 # Change me
       #matchRelease: false / true
+
+  lists:
+    - name: Latest TV Shows
+      type: mdblist
+      url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
+      filters:
+        - 1 # Change me
+    - name: Anticipated TV
+      type: trakt
+      url: https://api.autobrr.com/lists/trakt/anticipated-tv
+      filters:
+        - 22 # Change me
+
+    - name: Upcoming Movies
+      type: trakt
+      url: https://api.autobrr.com/lists/trakt/upcoming-movies
+      filters:
+        - 21 # Change me
+
+    - name: Upcoming Bluray
+      type: trakt
+      url: https://api.autobrr.com/lists/trakt/upcoming-bluray
+      filters:
+        - 24 # Change me
+
+    - name: Popular TV
+      type: trakt
+      url: https://api.autobrr.com/lists/trakt/popular-tv
+      filters:
+        - 25 # Change me
+    
+    - name: StevenLu
+      type: trakt
+      url: https://api.autobrr.com/lists/stevenlu
+      filters:
+        - 23 # Change me
+
+    - name: New Albums
+      type: metacritic
+      url: https://api.autobrr.com/lists/metacritic/new-albums
+      filters:
+        - 9 # Change me
+    - name: Upcoming Albums
+      type: metacritic
+      url: https://api.autobrr.com/lists/metacritic/upcoming-albums
+      filters:
+        - 20 # Change me

--- a/config.yml
+++ b/config.yml
@@ -61,49 +61,49 @@ clients:
         - 69 # Change me
       #matchRelease: false / true
 
-  lists:
-    - name: Latest TV Shows
-      type: mdblist
-      url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
-      filters:
-        - 1 # Change me
-    - name: Anticipated TV
-      type: trakt
-      url: https://api.autobrr.com/lists/trakt/anticipated-tv
-      filters:
-        - 22 # Change me
+lists:
+  - name: Latest TV Shows
+    type: mdblist
+    url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
+    filters:
+      - 1 # Change me
+  - name: Anticipated TV
+    type: trakt
+    url: https://api.autobrr.com/lists/trakt/anticipated-tv
+    filters:
+      - 22 # Change me
 
-    - name: Upcoming Movies
-      type: trakt
-      url: https://api.autobrr.com/lists/trakt/upcoming-movies
-      filters:
-        - 21 # Change me
+  - name: Upcoming Movies
+    type: trakt
+    url: https://api.autobrr.com/lists/trakt/upcoming-movies
+    filters:
+      - 21 # Change me
 
-    - name: Upcoming Bluray
-      type: trakt
-      url: https://api.autobrr.com/lists/trakt/upcoming-bluray
-      filters:
-        - 24 # Change me
+  - name: Upcoming Bluray
+    type: trakt
+    url: https://api.autobrr.com/lists/trakt/upcoming-bluray
+    filters:
+      - 24 # Change me
 
-    - name: Popular TV
-      type: trakt
-      url: https://api.autobrr.com/lists/trakt/popular-tv
-      filters:
-        - 25 # Change me
-    
-    - name: StevenLu
-      type: trakt
-      url: https://api.autobrr.com/lists/stevenlu
-      filters:
-        - 23 # Change me
+  - name: Popular TV
+    type: trakt
+    url: https://api.autobrr.com/lists/trakt/popular-tv
+    filters:
+      - 25 # Change me
 
-    - name: New Albums
-      type: metacritic
-      url: https://api.autobrr.com/lists/metacritic/new-albums
-      filters:
-        - 9 # Change me
-    - name: Upcoming Albums
-      type: metacritic
-      url: https://api.autobrr.com/lists/metacritic/upcoming-albums
-      filters:
-        - 20 # Change me
+  - name: StevenLu
+    type: trakt
+    url: https://api.autobrr.com/lists/stevenlu
+    filters:
+      - 23 # Change me
+
+  - name: New Albums
+    type: metacritic
+    url: https://api.autobrr.com/lists/metacritic/new-albums
+    filters:
+      - 9 # Change me
+  - name: Upcoming Albums
+    type: metacritic
+    url: https://api.autobrr.com/lists/metacritic/upcoming-albums
+    filters:
+      - 20 # Change me

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/autobrr/omegabrr
 go 1.19
 
 require (
+	github.com/fatih/color v1.9.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/render v1.0.2
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -77,8 +77,8 @@ type Config struct {
 	Clients  struct {
 		Autobrr *AutobrrConfig `koanf:"autobrr"`
 		Arr     []*ArrConfig   `koanf:"arr"`
-		Lists   []*ListConfig  `koanf:"lists"`
 	} `koanf:"clients"`
+	Lists []*ListConfig `koanf:"lists"`
 }
 
 func (c *Config) defaults() {
@@ -89,7 +89,7 @@ func (c *Config) defaults() {
 
 	c.Clients.Autobrr = nil
 	c.Clients.Arr = nil
-	c.Clients.Lists = nil
+	c.Lists = nil
 }
 
 var k = koanf.New(".")
@@ -245,51 +245,52 @@ clients:
     #  filters:
     #    - 69 # Change me
 
-  lists:
-    #- name: Latest TV Shows
-    #  type: mdblist
-    #  url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
-    #  filters:
-    #    - 1 # Change me
+lists:
+  #- name: Latest TV Shows
+  #  type: mdblist
+  #  url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
+  #  filters:
+  #    - 1 # Change me
 
-    #- name: Anticipated TV
-    #  type: trakt
-    #  url: https://api.autobrr.com/lists/trakt/anticipated-tv
-    #  filters:
-    #    - 22 # Change me
+  #- name: Anticipated TV
+  #  type: trakt
+  #  url: https://api.autobrr.com/lists/trakt/anticipated-tv
+  #  filters:
+  #    - 22 # Change me
 
-    #- name: Upcoming Movies
-    #  type: trakt
-    #  url: https://api.autobrr.com/lists/trakt/upcoming-movies
-    #  filters:
-    #    - 21 # Change me
+  #- name: Upcoming Movies
+  #  type: trakt
+  #  url: https://api.autobrr.com/lists/trakt/upcoming-movies
+  #  filters:
+  #    - 21 # Change me
 
-    #- name: Upcoming Bluray
-    #  type: trakt
-    #  url: https://api.autobrr.com/lists/trakt/upcoming-bluray
-    #  filters:
-    #    - 24 # Change me
+  #- name: Upcoming Bluray
+  #  type: trakt
+  #  url: https://api.autobrr.com/lists/trakt/upcoming-bluray
+  #  filters:
+  #    - 24 # Change me
 
-    #- name: Popular TV
-    #  type: trakt
-    #  url: https://api.autobrr.com/lists/trakt/popular-tv
-    #  filters:
-    #    - 25 # Change me
+  #- name: Popular TV
+  #  type: trakt
+  #  url: https://api.autobrr.com/lists/trakt/popular-tv
+  #  filters:
+  #    - 25 # Change me
 
-    #- name: StevenLu
-    #  type: trakt
-    #  url: https://api.autobrr.com/lists/stevenlu
-    #  filters:
-    #    - 23 # Change me
+  #- name: StevenLu
+  #  type: trakt
+  #  url: https://api.autobrr.com/lists/stevenlu
+  #  filters:
+  #    - 23 # Change me
 
-    #- name: New Albums
-    #  type: metacritic
-    #  url: https://api.autobrr.com/lists/metacritic/new-albums
-    #  filters:
-    #    - 9 # Change me
+  #- name: New Albums
+  #  type: metacritic
+  #  url: https://api.autobrr.com/lists/metacritic/new-albums
+  #  filters:
+  #    - 9 # Change me
 
-    #- name: Upcoming Albums
-    #  type: metacritic
-    #  url: https://api.autobrr.com/lists/metacritic/upcoming-albums
-    #  filters:
-    #    - 20 # Change me`
+  #- name: Upcoming Albums
+  #  type: metacritic
+  #  url: https://api.autobrr.com/lists/metacritic/upcoming-albums
+  #  filters:
+  #    - 20 # Change me
+`

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -20,6 +20,14 @@ type BasicAuth struct {
 	Pass string `koanf:"pass"`
 }
 
+type RegbrrConfig struct {
+	Name         string  `koanf:"name"`
+	Type         ArrType `koanf:"type"`
+	Host         string  `koanf:"host"`
+	Filters      []int   `koanf:"filters"`
+	MatchRelease bool    `koanf:"matchRelease"`
+}
+
 type ArrConfig struct {
 	Name                   string     `koanf:"name"`
 	Type                   ArrType    `koanf:"type"`
@@ -41,6 +49,7 @@ var (
 	ArrTypeReadarr  ArrType = "readarr"
 	ArrTypeLidarr   ArrType = "lidarr"
 	ArrTypeWhisparr ArrType = "whisparr"
+	ArrTypeRegbrr   ArrType = "regbrr"
 )
 
 type AutobrrConfig struct {

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -202,82 +202,94 @@ clients:
   #    pass: password
 
   arr:
-  #  - name: radarr
-  #    type: radarr
-  #    host: http://localhost:7878
-  #    apikey: API_KEY
-  #    filters:
-  #      - 15 # Change me
+    #- name: radarr
+    #  type: radarr
+    #  host: http://localhost:7878
+    #  apikey: API_KEY
+    #  filters:
+    #    - 15 # Change me
 
-  #  - name: radarr4k
-  #    type: radarr
-  #    host: http://localhost:7878
-  #    apikey: API_KEY
-  #    filters:
-  #      - 16 # Change me
+    #- name: radarr4k
+    #  type: radarr
+    #  host: http://localhost:7878
+    #  apikey: API_KEY
+    #  filters:
+    #    - 16 # Change me
 
-  #  - name: sonarr
-  #    type: sonarr
-  #    host: http://localhost:8989
-  #    apikey: API_KEY
-  #    filters:
-  #      - 14 # Change me
-  #    #excludeAlternateTitles: true # defaults to false
+    #- name: sonarr
+    #  type: sonarr
+    #  host: http://localhost:8989
+    #  apikey: API_KEY
+    #  filters:
+    #    - 14 # Change me
+    #  #excludeAlternateTitles: true # defaults to false
 
-  #  - name: readarr
-  #    type: readarr
-  #    host: http://localhost:8787
-  #    apikey: API_KEY
-  #    filters:
-  #      - 18 # Change me
+    #- name: readarr
+    #  type: readarr
+    #  host: http://localhost:8787
+    #  apikey: API_KEY
+    #  filters:
+    #    - 18 # Change me
 
-  #  - name: lidarr
-  #    type: lidarr
-  #    host: http://localhost:8686
-  #    apikey: API_KEY
-  #    filters:
-  #      - 32 # Change me
+    #- name: lidarr
+    #  type: lidarr
+    #  host: http://localhost:8686
+    #  apikey: API_KEY
+    #  filters:
+    #    - 32 # Change me
 
-  #  - name: whisparr
-  #    type: whisparr
-  #    host: http://localhost:6969
-  #    apikey: API_KEY
-  #    filters:
-  #      - 69 # Change me
-  
+    #- name: whisparr
+    #  type: whisparr
+    #  host: http://localhost:6969
+    #  apikey: API_KEY
+    #  filters:
+    #    - 69 # Change me
+
   lists:
-  #  - name: upcoming-bluray
-  #    type: trakt
-  #    url: https://sudoer.dev/bluray.json
-  #    filters:
-  #      - 17 # Change me
+    #- name: Latest TV Shows
+    #  type: mdblist
+    #  url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
+    #  filters:
+    #    - 1 # Change me
 
-  #  - name: upcoming-movies
-  #    type: trakt
-  #    url: https://sudoer.dev/movies.json
-  #    filters:
-  #      - 17 # Change me
+    #- name: Anticipated TV
+    #  type: trakt
+    #  url: https://api.autobrr.com/lists/trakt/anticipated-tv
+    #  filters:
+    #    - 22 # Change me
 
-  #  - name: popular-shows
-  #    type: trakt
-  #    url: https://sudoer.dev/tv.json
-  #    filters:
-  #      - 17 # Change me
+    #- name: Upcoming Movies
+    #  type: trakt
+    #  url: https://api.autobrr.com/lists/trakt/upcoming-movies
+    #  filters:
+    #    - 21 # Change me
 
-  #  - name: trakt-anticipated-shows
-  #    type: trakt
-  #    url: https://sudoer.dev/ant.json
-  #    filters:
-  #      - 17 # Change me
+    #- name: Upcoming Bluray
+    #  type: trakt
+    #  url: https://api.autobrr.com/lists/trakt/upcoming-bluray
+    #  filters:
+    #    - 24 # Change me
 
-  #  - name: latest-tv-shows
-  #    type: mdblist
-  #    url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
-  #    filters:
-  #    - 18 # Change me
+    #- name: Popular TV
+    #  type: trakt
+    #  url: https://api.autobrr.com/lists/trakt/popular-tv
+    #  filters:
+    #    - 25 # Change me
 
-  #  - name: custom-titles-line-by-line
-  #    type: plaintext
-  #    url: # only pages with contentType "text/plain"
-  #    filters:
-  #    - 19 # Change me`
+    #- name: StevenLu
+    #  type: trakt
+    #  url: https://api.autobrr.com/lists/stevenlu
+    #  filters:
+    #    - 23 # Change me
+
+    #- name: New Albums
+    #  type: metacritic
+    #  url: https://api.autobrr.com/lists/metacritic/new-albums
+    #  filters:
+    #    - 9 # Change me
+
+    #- name: Upcoming Albums
+    #  type: metacritic
+    #  url: https://api.autobrr.com/lists/metacritic/upcoming-albums
+    #  filters:
+    #    - 20 # Change me`

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -20,6 +20,23 @@ type BasicAuth struct {
 	Pass string `koanf:"pass"`
 }
 
+type ListConfig struct {
+	Name         string     `koanf:"name"`
+	Type         ListType   `koanf:"type"`
+	URL          string     `koanf:"url"`
+	BasicAuth    *BasicAuth `koanf:"basicAuth"`
+	Filters      []int      `koanf:"filters"`
+	MatchRelease bool       `koanf:"matchRelease"`
+}
+
+type ListType string
+
+var (
+	ListTypeTrakt     ListType = "trakt"
+	ListTypeMdblist   ListType = "mdblist"
+	ListTypePlaintext ListType = "plaintext"
+)
+
 type ArrConfig struct {
 	Name                   string     `koanf:"name"`
 	Type                   ArrType    `koanf:"type"`
@@ -41,7 +58,6 @@ var (
 	ArrTypeReadarr  ArrType = "readarr"
 	ArrTypeLidarr   ArrType = "lidarr"
 	ArrTypeWhisparr ArrType = "whisparr"
-	ArrTypeRegbrr   ArrType = "regbrr"
 )
 
 type AutobrrConfig struct {
@@ -60,6 +76,7 @@ type Config struct {
 	Clients  struct {
 		Autobrr *AutobrrConfig `koanf:"autobrr"`
 		Arr     []*ArrConfig   `koanf:"arr"`
+		Lists   []*ListConfig  `koanf:"lists"`
 	} `koanf:"clients"`
 }
 
@@ -71,6 +88,7 @@ func (c *Config) defaults() {
 
 	c.Clients.Autobrr = nil
 	c.Clients.Arr = nil
+	c.Clients.Lists = nil
 }
 
 var k = koanf.New(".")
@@ -224,4 +242,41 @@ clients:
   #    host: http://localhost:6969
   #    apikey: API_KEY
   #    filters:
-  #      - 69 # Change me`
+  #      - 69 # Change me
+  
+  lists:
+  #  - name: upcoming-bluray
+  #    type: trakt
+  #    url: https://sudoer.dev/bluray.json
+  #    filters:
+  #      - 17 # Change me
+
+  #  - name: upcoming-movies
+  #    type: trakt
+  #    url: https://sudoer.dev/movies.json
+  #    filters:
+  #      - 17 # Change me
+
+  #  - name: popular-shows
+  #    type: trakt
+  #    url: https://sudoer.dev/tv.json
+  #    filters:
+  #      - 17 # Change me
+
+  #  - name: trakt-anticipated-shows
+  #    type: trakt
+  #    url: https://sudoer.dev/ant.json
+  #    filters:
+  #      - 17 # Change me
+
+  #  - name: latest-tv-shows
+  #    type: mdblist
+  #    url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
+  #    filters:
+  #    - 18 # Change me
+
+  #  - name: custom-titles-line-by-line
+  #    type: plaintext
+  #    url: # only pages with contentType "text/plain"
+  #    filters:
+  #    - 19 # Change me`

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -20,14 +20,6 @@ type BasicAuth struct {
 	Pass string `koanf:"pass"`
 }
 
-type RegbrrConfig struct {
-	Name         string  `koanf:"name"`
-	Type         ArrType `koanf:"type"`
-	Host         string  `koanf:"host"`
-	Filters      []int   `koanf:"filters"`
-	MatchRelease bool    `koanf:"matchRelease"`
-}
-
 type ArrConfig struct {
 	Name                   string     `koanf:"name"`
 	Type                   ArrType    `koanf:"type"`

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -32,9 +32,10 @@ type ListConfig struct {
 type ListType string
 
 var (
-	ListTypeTrakt     ListType = "trakt"
-	ListTypeMdblist   ListType = "mdblist"
-	ListTypePlaintext ListType = "plaintext"
+	ListTypeTrakt      ListType = "trakt"
+	ListTypeMdblist    ListType = "mdblist"
+	ListTypeMetacritic ListType = "metacritic"
+	ListTypePlaintext  ListType = "plaintext"
 )
 
 type ArrConfig struct {

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -21,12 +21,13 @@ type BasicAuth struct {
 }
 
 type ListConfig struct {
-	Name         string     `koanf:"name"`
-	Type         ListType   `koanf:"type"`
-	URL          string     `koanf:"url"`
-	BasicAuth    *BasicAuth `koanf:"basicAuth"`
-	Filters      []int      `koanf:"filters"`
-	MatchRelease bool       `koanf:"matchRelease"`
+	Name         string            `koanf:"name"`
+	Type         ListType          `koanf:"type"`
+	URL          string            `koanf:"url"`
+	BasicAuth    *BasicAuth        `koanf:"basicAuth"`
+	Filters      []int             `koanf:"filters"`
+	MatchRelease bool              `koanf:"matchRelease"`
+	Headers      map[string]string `koanf:"headers"`
 }
 
 type ListType string

--- a/internal/processor/lidarr.go
+++ b/internal/processor/lidarr.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -47,7 +48,7 @@ func (s Service) lidarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 		if !dryRun {
 			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
 				l.Error().Err(err).Msgf("something went wrong updating music filter: %v", filterID)
-				continue
+				return fmt.Errorf("error updating music filter: %v, %w", filterID, err)
 			}
 		}
 

--- a/internal/processor/mdblist.go
+++ b/internal/processor/mdblist.go
@@ -23,10 +23,6 @@ func (s Service) mdblist(ctx context.Context, cfg *domain.ListConfig, dryRun boo
 
 	var titles []string
 
-	if !strings.HasPrefix(cfg.URL, "https://mdblist.com/") || !strings.HasSuffix(cfg.URL, "/json") {
-		return fmt.Errorf("invalid URL: %s, URL should start with https://mdblist.com and end with /json", cfg.URL)
-	}
-
 	green := color.New(color.FgGreen).SprintFunc()
 	l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
 

--- a/internal/processor/mdblist.go
+++ b/internal/processor/mdblist.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"strings"
-
 	"github.com/autobrr/omegabrr/internal/domain"
 	"github.com/autobrr/omegabrr/pkg/autobrr"
 	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
+	"net/http"
+	"strings"
 )
 
 func (s Service) mdblist(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
@@ -31,7 +30,17 @@ func (s Service) mdblist(ctx context.Context, cfg *domain.ListConfig, dryRun boo
 	green := color.New(color.FgGreen).SprintFunc()
 	l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
 
-	resp, err := http.Get(cfg.URL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.URL, nil)
+	if err != nil {
+		l.Error().Err(err).Msg("could not make new request")
+		return err
+	}
+
+	for k, v := range cfg.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.URL)
 		return err

--- a/internal/processor/mdblist.go
+++ b/internal/processor/mdblist.go
@@ -69,6 +69,7 @@ func (s Service) mdblist(ctx context.Context, cfg *domain.ListConfig, dryRun boo
 		l.Trace().Msgf("%s", joinedTitles)
 
 		if len(joinedTitles) == 0 {
+			l.Debug().Msgf("no titles found for filter: %v", filterID)
 			return nil
 		}
 

--- a/internal/processor/mdblist.go
+++ b/internal/processor/mdblist.go
@@ -1,0 +1,82 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/autobrr/omegabrr/internal/domain"
+	"github.com/autobrr/omegabrr/pkg/autobrr"
+	"github.com/fatih/color"
+	"github.com/rs/zerolog/log"
+)
+
+func (s Service) mdblist(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
+	l := log.With().Str("type", "mdblist").Str("client", cfg.Name).Logger()
+
+	var titles []string
+
+	if !strings.HasPrefix(cfg.URL, "https://mdblist.com/") || !strings.HasSuffix(cfg.URL, "/json") {
+		return fmt.Errorf("invalid URL: %s, URL should start with https://mdblist.com and end with /json", cfg.URL)
+	}
+
+	green := color.New(color.FgGreen).SprintFunc()
+	l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
+
+	resp, err := http.Get(cfg.URL)
+	if err != nil {
+		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.URL)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		l.Error().Msgf("failed to fetch titles from URL: %s", cfg.URL)
+		return fmt.Errorf("failed to fetch titles from URL: %s", cfg.URL)
+	}
+
+	var data []struct {
+		Title string `json:"title"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		l.Error().Err(err).Msgf("failed to decode JSON data from URL: %s", cfg.URL)
+		return err
+	}
+
+	for _, item := range data {
+		titles = append(titles, item.Title)
+	}
+
+	for _, filterID := range cfg.Filters {
+		l.Debug().Msgf("updating filter: %v", filterID)
+
+		filterTitles := []string{}
+		for _, title := range titles {
+			filterTitles = append(filterTitles, processTitle(title, cfg.MatchRelease)...)
+		}
+
+		joinedTitles := strings.Join(filterTitles, ",")
+
+		l.Trace().Msgf("%s", joinedTitles)
+
+		if len(joinedTitles) == 0 {
+			return nil
+		}
+
+		f := autobrr.UpdateFilter{Shows: strings.Join(filterTitles, ",")}
+
+		if !dryRun {
+			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+				l.Error().Err(err).Msgf("something went wrong updating filter: %v", filterID)
+				continue
+			}
+		}
+
+		l.Debug().Msgf("successfully updated filter: %v", filterID)
+	}
+
+	return nil
+}

--- a/internal/processor/mdblist.go
+++ b/internal/processor/mdblist.go
@@ -77,7 +77,7 @@ func (s Service) mdblist(ctx context.Context, cfg *domain.ListConfig, dryRun boo
 		if !dryRun {
 			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
 				l.Error().Err(err).Msgf("something went wrong updating filter: %v", filterID)
-				continue
+				return fmt.Errorf("error updating filter: %v, %w", filterID, err)
 			}
 		}
 

--- a/internal/processor/mdblist.go
+++ b/internal/processor/mdblist.go
@@ -16,6 +16,12 @@ import (
 func (s Service) mdblist(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
 	l := log.With().Str("type", "mdblist").Str("client", cfg.Name).Logger()
 
+	if cfg.URL == "" {
+		errMsg := "no URL provided for Mdblist"
+		l.Error().Msg(errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
 	var titles []string
 
 	if !strings.HasPrefix(cfg.URL, "https://mdblist.com/") || !strings.HasSuffix(cfg.URL, "/json") {

--- a/internal/processor/mdblist_test.go
+++ b/internal/processor/mdblist_test.go
@@ -21,12 +21,13 @@ func TestMDBList(t *testing.T) {
 
 	cfg := &domain.ListConfig{
 		Name: "test",
-		URL:  "https://mdblist.com/lists/linaspurinis/top-watched-movies-of-the-week/json",
+		//URL:  "https://mdblist.com/lists/linaspurinis/top-watched-movies-of-the-week/json",
+		URL: ts.URL,
 	}
 
 	brr := &autobrr.Client{}
 
-	service := Service{}
+	service := NewService(nil)
 
 	err := service.mdblist(context.Background(), cfg, false, brr)
 	if err != nil {

--- a/internal/processor/mdblist_test.go
+++ b/internal/processor/mdblist_test.go
@@ -11,19 +11,6 @@ import (
 	"github.com/autobrr/omegabrr/pkg/autobrr"
 )
 
-// Tests that an error is returned when an invalid URL is passed to the `mdblist` function
-func TestMdblist_InvalidURL(t *testing.T) {
-
-	s := Service{}
-
-	cfg := &domain.ListConfig{Name: "test list", URL: "http://example.com"}
-
-	err := s.mdblist(context.Background(), cfg, false, nil)
-	if err == nil {
-		t.Error("expected error, got nil")
-	}
-}
-
 // Unit test for the `mdblist` function with mocked dependencies.
 func TestMDBList(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/processor/mdblist_test.go
+++ b/internal/processor/mdblist_test.go
@@ -1,0 +1,48 @@
+package processor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/autobrr/omegabrr/internal/domain"
+	"github.com/autobrr/omegabrr/pkg/autobrr"
+)
+
+// Tests that an error is returned when an invalid URL is passed to the `mdblist` function
+func TestMdblist_InvalidURL(t *testing.T) {
+
+	s := Service{}
+
+	cfg := &domain.ListConfig{Name: "test list", URL: "http://example.com"}
+
+	err := s.mdblist(context.Background(), cfg, false, nil)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+// Unit test for the `mdblist` function with mocked dependencies.
+func TestMDBList(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return sample JSON response for testing
+		fmt.Fprintln(w, `[{"title": "Movie 1"}, {"title": "Movie 2"}]`)
+	}))
+	defer ts.Close()
+
+	cfg := &domain.ListConfig{
+		Name: "test",
+		URL:  "https://mdblist.com/lists/linaspurinis/top-watched-movies-of-the-week/json",
+	}
+
+	brr := &autobrr.Client{}
+
+	service := Service{}
+
+	err := service.mdblist(context.Background(), cfg, false, brr)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/processor/metacritic.go
+++ b/internal/processor/metacritic.go
@@ -86,10 +86,7 @@ func (s Service) metacritic(ctx context.Context, cfg *domain.ListConfig, dryRun 
 		l.Trace().Msgf("%s", joinedTitles)
 
 		if len(joinedTitles) == 0 {
-			if strings.Contains(cfg.URL, "mdblist.com") {
-				l.Error().Msgf("Found no titles in %s", cfg.URL)
-				l.Error().Msgf("Are you sure this is a metacritic.tv JSON?")
-			}
+			l.Debug().Msgf("no titles found for filter: %v", filterID)
 			return nil
 		}
 

--- a/internal/processor/metacritic.go
+++ b/internal/processor/metacritic.go
@@ -27,7 +27,17 @@ func (s Service) metacritic(ctx context.Context, cfg *domain.ListConfig, dryRun 
 	green := color.New(color.FgGreen).SprintFunc()
 	l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
 
-	resp, err := http.Get(cfg.URL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.URL, nil)
+	if err != nil {
+		l.Error().Err(err).Msg("could not make new request")
+		return err
+	}
+
+	for k, v := range cfg.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.URL)
 		return err

--- a/internal/processor/metacritic.go
+++ b/internal/processor/metacritic.go
@@ -16,11 +16,6 @@ import (
 func (s Service) metacritic(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
 	l := log.With().Str("type", "metacritic").Str("client", cfg.Name).Logger()
 
-	// Validate the input URL
-	//if !strings.HasPrefix(cfg.URL, "https://sudoer.dev") {
-	//	return fmt.Errorf("invalid URL provided for Metacritic list, URL must start with https://api.autobrr.com/metacritic. For supported lists, please refer to the README")
-	//}
-
 	if cfg.URL == "" {
 		errMsg := "no URL provided for Metacritic list"
 		l.Error().Msg(errMsg)

--- a/internal/processor/metacritic.go
+++ b/internal/processor/metacritic.go
@@ -1,0 +1,113 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/autobrr/omegabrr/internal/domain"
+	"github.com/autobrr/omegabrr/pkg/autobrr"
+	"github.com/fatih/color"
+	"github.com/rs/zerolog/log"
+)
+
+func (s Service) metacritic(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
+	l := log.With().Str("type", "metacritic").Str("client", cfg.Name).Logger()
+
+	// Validate the input URL
+	//if !strings.HasPrefix(cfg.URL, "https://sudoer.dev") {
+	//	return fmt.Errorf("invalid URL provided for Metacritic list, URL must start with https://api.autobrr.com/metacritic. For supported lists, please refer to the README")
+	//}
+
+	if cfg.URL == "" {
+		errMsg := "no URL provided for Metacritic list"
+		l.Error().Msg(errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	var titles []string
+
+	green := color.New(color.FgGreen).SprintFunc()
+	l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
+
+	resp, err := http.Get(cfg.URL)
+	if err != nil {
+		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.URL)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		errMsg := fmt.Sprintf("No endpoint found at %v. (404 Not Found)", cfg.URL)
+		l.Error().Msg(errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		l.Error().Msgf("failed to fetch titles from URL: %s", cfg.URL)
+		return fmt.Errorf("failed to fetch titles from URL: %s", cfg.URL)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		errMsg := fmt.Sprintf("invalid content type for URL: %s, content type should be application/json", cfg.URL)
+		return fmt.Errorf(errMsg)
+	}
+
+	var data struct {
+		Title  string `json:"title"`
+		Albums []struct {
+			Artist string `json:"artist"`
+			Title  string `json:"title"`
+		} `json:"albums"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		l.Error().Err(err).Msgf("failed to decode JSON data from URL: %s", cfg.URL)
+		return err
+	}
+
+	for _, album := range data.Albums {
+		titles = append(titles, album.Title)
+	}
+
+	for _, filterID := range cfg.Filters {
+		l.Debug().Msgf("updating filter: %v", filterID)
+
+		filterTitles := []string{}
+		for _, title := range titles {
+			filterTitles = append(filterTitles, processTitle(title, cfg.MatchRelease)...)
+		}
+
+		joinedTitles := strings.Join(filterTitles, ",")
+
+		l.Trace().Msgf("%s", joinedTitles)
+
+		if len(joinedTitles) == 0 {
+			if strings.Contains(cfg.URL, "mdblist.com") {
+				l.Error().Msgf("Found no titles in %s", cfg.URL)
+				l.Error().Msgf("Are you sure this is a metacritic.tv JSON?")
+			}
+			return nil
+		}
+
+		f := autobrr.UpdateFilter{Albums: joinedTitles}
+
+		if cfg.MatchRelease {
+			f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
+		}
+
+		if !dryRun {
+			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+				l.Error().Err(err).Msgf("something went wrong updating filter: %v", filterID)
+				return fmt.Errorf("error updating filter: %v, %w", filterID, err)
+			}
+		}
+
+		l.Debug().Msgf("successfully updated filter: %v", filterID)
+	}
+
+	return nil
+}

--- a/internal/processor/plaintext.go
+++ b/internal/processor/plaintext.go
@@ -1,0 +1,86 @@
+package processor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/autobrr/omegabrr/internal/domain"
+	"github.com/autobrr/omegabrr/pkg/autobrr"
+	"github.com/fatih/color"
+	"github.com/rs/zerolog/log"
+)
+
+func (s Service) plaintext(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
+	l := log.With().Str("type", "plaintext").Str("client", cfg.Name).Logger()
+
+	var titles []string
+
+	green := color.New(color.FgGreen).SprintFunc()
+	l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
+
+	resp, err := http.Get(cfg.URL)
+	if err != nil {
+		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.URL)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		l.Error().Msgf("failed to fetch titles from URL: %s", cfg.URL)
+		return fmt.Errorf("failed to fetch titles from URL: %s", cfg.URL)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "text/plain") {
+		l.Error().Msgf("failed to fetch plaintext from URL: %s", cfg.URL)
+		return fmt.Errorf("failed to fetch plaintext from URL: %s", cfg.URL)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		l.Error().Err(err).Msgf("failed to read response body from URL: %s", cfg.URL)
+		return err
+	}
+
+	titleLines := strings.Split(string(body), "\n")
+	for _, titleLine := range titleLines {
+		title := strings.TrimSpace(titleLine)
+		if title == "" {
+			continue
+		}
+		titles = append(titles, title)
+	}
+
+	for _, filterID := range cfg.Filters {
+		l.Debug().Msgf("updating filter: %v", filterID)
+
+		filterTitles := []string{}
+		for _, title := range titles {
+			filterTitles = append(filterTitles, processTitle(title, cfg.MatchRelease)...)
+		}
+
+		joinedTitles := strings.Join(filterTitles, ",")
+
+		l.Trace().Msgf("%s", joinedTitles)
+
+		if len(joinedTitles) == 0 {
+			return nil
+		}
+
+		f := autobrr.UpdateFilter{Shows: strings.Join(filterTitles, ",")}
+
+		if !dryRun {
+			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+				l.Error().Err(err).Msgf("something went wrong updating filter: %v", filterID)
+				continue
+			}
+		}
+
+		l.Debug().Msgf("successfully updated filter: %v", filterID)
+	}
+
+	return nil
+}

--- a/internal/processor/plaintext.go
+++ b/internal/processor/plaintext.go
@@ -73,6 +73,7 @@ func (s Service) plaintext(ctx context.Context, cfg *domain.ListConfig, dryRun b
 		l.Trace().Msgf("%s", joinedTitles)
 
 		if len(joinedTitles) == 0 {
+			l.Debug().Msgf("no titles found for filter: %v", filterID)
 			return nil
 		}
 

--- a/internal/processor/plaintext.go
+++ b/internal/processor/plaintext.go
@@ -16,6 +16,12 @@ import (
 func (s Service) plaintext(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
 	l := log.With().Str("type", "plaintext").Str("client", cfg.Name).Logger()
 
+	if cfg.URL == "" {
+		errMsg := fmt.Sprintf("no URL provided for plaintext list: %s", cfg.Name)
+		l.Error().Msg(errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
 	var titles []string
 
 	green := color.New(color.FgGreen).SprintFunc()

--- a/internal/processor/plaintext.go
+++ b/internal/processor/plaintext.go
@@ -81,7 +81,7 @@ func (s Service) plaintext(ctx context.Context, cfg *domain.ListConfig, dryRun b
 		if !dryRun {
 			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
 				l.Error().Err(err).Msgf("something went wrong updating filter: %v", filterID)
-				continue
+				return fmt.Errorf("error updating filter: %v, %w", filterID, err)
 			}
 		}
 

--- a/internal/processor/plaintext.go
+++ b/internal/processor/plaintext.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/autobrr/omegabrr/internal/domain"
 	"github.com/autobrr/omegabrr/pkg/autobrr"
+
 	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
 )
@@ -27,7 +28,17 @@ func (s Service) plaintext(ctx context.Context, cfg *domain.ListConfig, dryRun b
 	green := color.New(color.FgGreen).SprintFunc()
 	l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
 
-	resp, err := http.Get(cfg.URL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.URL, nil)
+	if err != nil {
+		l.Error().Err(err).Msg("could not make new request")
+		return err
+	}
+
+	for k, v := range cfg.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.URL)
 		return err

--- a/internal/processor/radarr.go
+++ b/internal/processor/radarr.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -47,7 +48,7 @@ func (s Service) radarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 		if !dryRun {
 			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
 				l.Error().Err(err).Msgf("something went wrong updating movie filter: %v", filterID)
-				continue
+				return fmt.Errorf("error updating movie filter: %v, %w", filterID, err)
 			}
 		}
 

--- a/internal/processor/readarr.go
+++ b/internal/processor/readarr.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -41,9 +42,11 @@ func (s Service) readarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool
 		if !dryRun {
 			f := autobrr.UpdateFilter{MatchReleases: joinedTitles}
 
-			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
-				l.Error().Err(err).Msgf("something went wrong updating ebook filter: %v", filterID)
-				continue
+			if !dryRun {
+				if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+					l.Error().Err(err).Msgf("something went wrong updating ebook filter: %v", filterID)
+					return fmt.Errorf("error updating ebook filter: %v, %w", filterID, err)
+				}
 			}
 		}
 

--- a/internal/processor/regbrr.go
+++ b/internal/processor/regbrr.go
@@ -34,6 +34,7 @@ func (s Service) regbrr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 		}
 
 		var data []struct {
+			Title string `json:"title"`
 			Movie struct {
 				Title string `json:"title"`
 			} `json:"movie"`
@@ -48,6 +49,7 @@ func (s Service) regbrr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 		}
 
 		for _, item := range data {
+			titles = append(titles, item.Title)
 			if item.Movie.Title != "" {
 				titles = append(titles, item.Movie.Title)
 			}

--- a/internal/processor/regbrr.go
+++ b/internal/processor/regbrr.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,37 +16,78 @@ import (
 func (s Service) regbrr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool, brr *autobrr.Client) error {
 	l := log.With().Str("type", "regbrr").Str("client", cfg.Name).Logger()
 
-	l.Debug().Msgf("fetching titles from URL: %s", cfg.Host)
+	var titles []string
 
-	resp, err := http.Get(cfg.Host)
-	if err != nil {
-		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.Host)
-		return err
-	}
-	defer resp.Body.Close()
+	if strings.HasSuffix(cfg.Host, ".json") {
+		l.Debug().Msgf("fetching titles from JSON URL: %s", cfg.Host)
 
-	if resp.StatusCode != http.StatusOK {
-		l.Error().Msgf("failed to fetch titles from URL: %s", cfg.Host)
-		return fmt.Errorf("failed to fetch titles from URL: %s", cfg.Host)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		l.Error().Err(err).Msgf("failed to read response body from URL: %s", cfg.Host)
-		return err
-	}
-
-	titleLines := strings.Split(string(body), "\n")
-	titles := []string{}
-	for _, titleLine := range titleLines {
-		title := strings.TrimSpace(titleLine)
-		if title == "" {
-			continue
+		resp, err := http.Get(cfg.Host)
+		if err != nil {
+			l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.Host)
+			return err
 		}
-		titles = append(titles, title)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			l.Error().Msgf("failed to fetch titles from URL: %s", cfg.Host)
+			return fmt.Errorf("failed to fetch titles from URL: %s", cfg.Host)
+		}
+
+		var data []struct {
+			Movie struct {
+				Title string `json:"title"`
+			} `json:"movie"`
+			Show struct {
+				Title string `json:"title"`
+			} `json:"show"`
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			l.Error().Err(err).Msgf("failed to decode JSON data from URL: %s", cfg.Host)
+			return err
+		}
+
+		for _, item := range data {
+			if item.Movie.Title != "" {
+				titles = append(titles, item.Movie.Title)
+			}
+			if item.Show.Title != "" {
+				titles = append(titles, item.Show.Title)
+			}
+		}
+
+	} else {
+		l.Debug().Msgf("fetching titles from URL: %s", cfg.Host)
+
+		resp, err := http.Get(cfg.Host)
+		if err != nil {
+			l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.Host)
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			l.Error().Msgf("failed to fetch titles from URL: %s", cfg.Host)
+			return fmt.Errorf("failed to fetch titles from URL: %s", cfg.Host)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			l.Error().Err(err).Msgf("failed to read response body from URL: %s", cfg.Host)
+			return err
+		}
+
+		titleLines := strings.Split(string(body), "\n")
+		for _, titleLine := range titleLines {
+			title := strings.TrimSpace(titleLine)
+			if title == "" {
+				continue
+			}
+			titles = append(titles, title)
+		}
 	}
 
-	l.Debug().Msgf("gathered titles: %v", titles)
+	//l.Debug().Msgf("gathered titles: %s", strings.ReplaceAll(strings.Join(titles, ", "), ", ", ","))
 
 	for _, filterID := range cfg.Filters {
 		l.Debug().Msgf("updating filter: %v", filterID)
@@ -53,6 +95,14 @@ func (s Service) regbrr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 		filterTitles := []string{}
 		for _, title := range titles {
 			filterTitles = append(filterTitles, processTitle(title, cfg.MatchRelease)...)
+		}
+
+		joinedTitles := strings.Join(filterTitles, ",")
+
+		l.Trace().Msgf("%s", joinedTitles)
+
+		if len(joinedTitles) == 0 {
+			return nil
 		}
 
 		f := autobrr.UpdateFilter{Shows: strings.Join(filterTitles, ",")}

--- a/internal/processor/regbrr.go
+++ b/internal/processor/regbrr.go
@@ -1,0 +1,71 @@
+package processor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/autobrr/omegabrr/internal/domain"
+	"github.com/autobrr/omegabrr/pkg/autobrr"
+	"github.com/rs/zerolog/log"
+)
+
+func (s Service) regbrr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool, brr *autobrr.Client) error {
+	l := log.With().Str("type", "regbrr").Str("client", cfg.Name).Logger()
+
+	l.Debug().Msgf("fetching titles from URL: %s", cfg.Host)
+
+	resp, err := http.Get(cfg.Host)
+	if err != nil {
+		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.Host)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		l.Error().Msgf("failed to fetch titles from URL: %s", cfg.Host)
+		return fmt.Errorf("failed to fetch titles from URL: %s", cfg.Host)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		l.Error().Err(err).Msgf("failed to read response body from URL: %s", cfg.Host)
+		return err
+	}
+
+	titleLines := strings.Split(string(body), "\n")
+	titles := []string{}
+	for _, titleLine := range titleLines {
+		title := strings.TrimSpace(titleLine)
+		if title == "" {
+			continue
+		}
+		titles = append(titles, title)
+	}
+
+	l.Debug().Msgf("gathered titles: %v", titles)
+
+	for _, filterID := range cfg.Filters {
+		l.Debug().Msgf("updating filter: %v", filterID)
+
+		filterTitles := []string{}
+		for _, title := range titles {
+			filterTitles = append(filterTitles, processTitle(title, cfg.MatchRelease)...)
+		}
+
+		f := autobrr.UpdateFilter{Shows: strings.Join(filterTitles, ",")}
+
+		if !dryRun {
+			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
+				l.Error().Err(err).Msgf("something went wrong updating filter: %v", filterID)
+				continue
+			}
+		}
+
+		l.Debug().Msgf("successfully updated filter: %v", filterID)
+	}
+
+	return nil
+}

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -16,11 +17,16 @@ import (
 
 type Service struct {
 	cfg *domain.Config
+
+	httpClient *http.Client
 }
 
 func NewService(cfg *domain.Config) *Service {
 	return &Service{
 		cfg: cfg,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
 	}
 }
 

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -26,8 +26,8 @@ func NewService(cfg *domain.Config) *Service {
 
 func (s Service) Process(dryRun bool) error {
 	if s.cfg.Clients.Autobrr == nil {
-		log.Fatal().Msg("must supply autobrr configuration!")
-		return errors.New("must supply autobrr configuration")
+		log.Fatal().Msg("must supply omegabrr configuration!")
+		return errors.New("must supply omegabrr configuration")
 	}
 
 	a := autobrr.NewClient(s.cfg.Clients.Autobrr.Host, s.cfg.Clients.Autobrr.Apikey)
@@ -183,8 +183,8 @@ func (s Service) Process(dryRun bool) error {
 
 func (s Service) GetFilters(ctx context.Context) ([]autobrr.Filter, error) {
 	if s.cfg.Clients.Autobrr == nil {
-		log.Fatal().Msg("must supply autobrr configuration!")
-		return nil, errors.New("must supply autobrr configuration")
+		log.Fatal().Msg("must supply omegabrr configuration!")
+		return nil, errors.New("must supply omegabrr configuration")
 	}
 
 	a := autobrr.NewClient(s.cfg.Clients.Autobrr.Host, s.cfg.Clients.Autobrr.Apikey)

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -111,8 +111,8 @@ func (s Service) Process(dryRun bool) error {
 		}
 	}
 
-	if s.cfg.Clients.Lists != nil {
-		for _, listsClient := range s.cfg.Clients.Lists {
+	if s.cfg.Lists != nil {
+		for _, listsClient := range s.cfg.Lists {
 			listsClient := listsClient
 
 			switch listsClient.Type {

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -81,18 +81,31 @@ func (s Service) Process(dryRun bool) error {
 			switch listsClient.Type {
 			case domain.ListTypeTrakt:
 				g.Go(func() error {
-					return s.trakt(ctx, listsClient, dryRun, a)
+					if err := s.trakt(ctx, listsClient, dryRun, a); err != nil {
+						log.Error().Err(err).Str("type", "trakt").Str("client", listsClient.Name).Msg("error while processing Trakt list, continuing with other lists")
+						return nil
+					}
+					return nil
 				})
 
 			case domain.ListTypeMdblist:
 				g.Go(func() error {
-					return s.mdblist(ctx, listsClient, dryRun, a)
+					if err := s.mdblist(ctx, listsClient, dryRun, a); err != nil {
+						log.Error().Err(err).Str("type", "mdblist").Str("client", listsClient.Name).Msg("error while processing Mdblist, continuing with other lists")
+						return nil
+					}
+					return nil
 				})
 
 			case domain.ListTypePlaintext:
 				g.Go(func() error {
-					return s.plaintext(ctx, listsClient, dryRun, a)
+					if err := s.plaintext(ctx, listsClient, dryRun, a); err != nil {
+						log.Error().Err(err).Str("type", "plaintext").Str("client", listsClient.Name).Msg("error while processing Plaintext list, continuing with other lists")
+						return nil
+					}
+					return nil
 				})
+
 			}
 		}
 	}

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -2,6 +2,8 @@ package processor
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/autobrr/omegabrr/internal/domain"
@@ -39,6 +41,12 @@ func (s Service) Process(dryRun bool) error {
 
 	g, ctx := errgroup.WithContext(context.Background())
 
+	// Create a slice to store errors
+	var processingErrors []string
+
+	// Use a mutex to protect the processingErrors slice
+	var mu sync.Mutex
+
 	if s.cfg.Clients.Arr != nil {
 		for _, arrClient := range s.cfg.Clients.Arr {
 			// https://golang.org/doc/faq#closures_and_goroutines
@@ -47,29 +55,58 @@ func (s Service) Process(dryRun bool) error {
 			switch arrClient.Type {
 			case domain.ArrTypeRadarr:
 				g.Go(func() error {
-					return s.radarr(ctx, arrClient, dryRun, a)
+					if err := s.radarr(ctx, arrClient, dryRun, a); err != nil {
+						log.Error().Err(err).Str("type", "radarr").Str("client", arrClient.Name).Msg("error while processing Radarr, continuing with other clients")
+						mu.Lock()
+						processingErrors = append(processingErrors, fmt.Sprintf("Radarr - %s: %v", arrClient.Name, err))
+						mu.Unlock()
+					}
+					return nil
 				})
 
 			case domain.ArrTypeWhisparr:
 				g.Go(func() error {
-					return s.radarr(ctx, arrClient, dryRun, a)
+					if err := s.radarr(ctx, arrClient, dryRun, a); err != nil {
+						log.Error().Err(err).Str("type", "whisparr").Str("client", arrClient.Name).Msg("error while processing Whisparr, continuing with other clients")
+						mu.Lock()
+						processingErrors = append(processingErrors, fmt.Sprintf("Whisparr - %s: %v", arrClient.Name, err))
+						mu.Unlock()
+					}
+					return nil
 				})
 
 			case domain.ArrTypeSonarr:
 				g.Go(func() error {
-					return s.sonarr(ctx, arrClient, dryRun, a)
+					if err := s.sonarr(ctx, arrClient, dryRun, a); err != nil {
+						log.Error().Err(err).Str("type", "sonarr").Str("client", arrClient.Name).Msg("error while processing Sonarr, continuing with other clients")
+						mu.Lock()
+						processingErrors = append(processingErrors, fmt.Sprintf("Sonarr - %s: %v", arrClient.Name, err))
+						mu.Unlock()
+					}
+					return nil
 				})
 
 			case domain.ArrTypeReadarr:
 				g.Go(func() error {
-					return s.readarr(ctx, arrClient, dryRun, a)
+					if err := s.readarr(ctx, arrClient, dryRun, a); err != nil {
+						log.Error().Err(err).Str("type", "readarr").Str("client", arrClient.Name).Msg("error while processing Readarr, continuing with other clients")
+						mu.Lock()
+						processingErrors = append(processingErrors, fmt.Sprintf("Readarr - %s: %v", arrClient.Name, err))
+						mu.Unlock()
+					}
+					return nil
 				})
 
 			case domain.ArrTypeLidarr:
 				g.Go(func() error {
-					return s.lidarr(ctx, arrClient, dryRun, a)
+					if err := s.lidarr(ctx, arrClient, dryRun, a); err != nil {
+						log.Error().Err(err).Str("type", "lidarr").Str("client", arrClient.Name).Msg("error while processing Lidarr, continuing with other clients")
+						mu.Lock()
+						processingErrors = append(processingErrors, fmt.Sprintf("Lidarr - %s: %v", arrClient.Name, err))
+						mu.Unlock()
+					}
+					return nil
 				})
-
 			}
 		}
 	}
@@ -83,7 +120,9 @@ func (s Service) Process(dryRun bool) error {
 				g.Go(func() error {
 					if err := s.trakt(ctx, listsClient, dryRun, a); err != nil {
 						log.Error().Err(err).Str("type", "trakt").Str("client", listsClient.Name).Msg("error while processing Trakt list, continuing with other lists")
-						return nil
+						mu.Lock()
+						processingErrors = append(processingErrors, fmt.Sprintf("Trakt - %s: %v", listsClient.Name, err))
+						mu.Unlock()
 					}
 					return nil
 				})
@@ -92,7 +131,9 @@ func (s Service) Process(dryRun bool) error {
 				g.Go(func() error {
 					if err := s.mdblist(ctx, listsClient, dryRun, a); err != nil {
 						log.Error().Err(err).Str("type", "mdblist").Str("client", listsClient.Name).Msg("error while processing Mdblist, continuing with other lists")
-						return nil
+						mu.Lock()
+						processingErrors = append(processingErrors, fmt.Sprintf("Mdblist - %s: %v", listsClient.Name, err))
+						mu.Unlock()
 					}
 					return nil
 				})
@@ -101,11 +142,12 @@ func (s Service) Process(dryRun bool) error {
 				g.Go(func() error {
 					if err := s.plaintext(ctx, listsClient, dryRun, a); err != nil {
 						log.Error().Err(err).Str("type", "plaintext").Str("client", listsClient.Name).Msg("error while processing Plaintext list, continuing with other lists")
-						return nil
+						mu.Lock()
+						processingErrors = append(processingErrors, fmt.Sprintf("Plaintext - %s: %v", listsClient.Name, err))
+						mu.Unlock()
 					}
 					return nil
 				})
-
 			}
 		}
 	}
@@ -116,6 +158,14 @@ func (s Service) Process(dryRun bool) error {
 	}
 
 	log.Info().Msgf("Successfully updated filters! Total time: %v", time.Since(start))
+
+	// Print the errors if there are any
+	if len(processingErrors) > 0 {
+		log.Warn().Msg("Errors encountered during processing:")
+		for _, errMsg := range processingErrors {
+			log.Warn().Msg(errMsg)
+		}
+	}
 
 	return nil
 }

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -138,6 +138,17 @@ func (s Service) Process(dryRun bool) error {
 					return nil
 				})
 
+			case domain.ListTypeMetacritic:
+				g.Go(func() error {
+					if err := s.metacritic(ctx, listsClient, dryRun, a); err != nil {
+						log.Error().Err(err).Str("type", "metacritic").Str("client", listsClient.Name).Msg("error while processing Metacritic, continuing with other lists")
+						mu.Lock()
+						processingErrors = append(processingErrors, fmt.Sprintf("Metacritic - %s: %v", listsClient.Name, err))
+						mu.Unlock()
+					}
+					return nil
+				})
+
 			case domain.ListTypePlaintext:
 				g.Go(func() error {
 					if err := s.plaintext(ctx, listsClient, dryRun, a); err != nil {

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -70,6 +70,11 @@ func (s Service) Process(dryRun bool) error {
 					return s.lidarr(ctx, arrClient, dryRun, a)
 				})
 
+			case domain.ArrTypeRegbrr:
+				g.Go(func() error {
+					return s.regbrr(ctx, arrClient, dryRun, a)
+				})
+
 			}
 		}
 	}

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -70,11 +70,29 @@ func (s Service) Process(dryRun bool) error {
 					return s.lidarr(ctx, arrClient, dryRun, a)
 				})
 
-			case domain.ArrTypeRegbrr:
+			}
+		}
+	}
+
+	if s.cfg.Clients.Lists != nil {
+		for _, listsClient := range s.cfg.Clients.Lists {
+			listsClient := listsClient
+
+			switch listsClient.Type {
+			case domain.ListTypeTrakt:
 				g.Go(func() error {
-					return s.regbrr(ctx, arrClient, dryRun, a)
+					return s.trakt(ctx, listsClient, dryRun, a)
 				})
 
+			case domain.ListTypeMdblist:
+				g.Go(func() error {
+					return s.mdblist(ctx, listsClient, dryRun, a)
+				})
+
+			case domain.ListTypePlaintext:
+				g.Go(func() error {
+					return s.plaintext(ctx, listsClient, dryRun, a)
+				})
 			}
 		}
 	}

--- a/internal/processor/sonarr.go
+++ b/internal/processor/sonarr.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -47,7 +48,7 @@ func (s Service) sonarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 		if !dryRun {
 			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
 				l.Error().Err(err).Msgf("something went wrong updating tv filter: %v", filterID)
-				continue
+				return fmt.Errorf("error updating tv filter: %v, %w", filterID, err)
 			}
 		}
 

--- a/internal/processor/trakt.go
+++ b/internal/processor/trakt.go
@@ -17,7 +17,7 @@ func (s Service) trakt(ctx context.Context, cfg *domain.ListConfig, dryRun bool,
 	l := log.With().Str("type", "trakt").Str("client", cfg.Name).Logger()
 
 	// Validate the input URL
-	if !strings.HasPrefix(cfg.URL, "https://api.autobrr.com/trakt") {
+	if !strings.HasPrefix(cfg.URL, "https://sudoer.dev") {
 		return fmt.Errorf("invalid URL provided for Trakt list, URL must start with https://api.autobrr.com/trakt. For supported lists, please refer to the README")
 	}
 

--- a/internal/processor/trakt.go
+++ b/internal/processor/trakt.go
@@ -16,49 +16,58 @@ import (
 func (s Service) trakt(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
 	l := log.With().Str("type", "trakt").Str("client", cfg.Name).Logger()
 
+	if cfg.URL == "" {
+		errMsg := "no URL provided for Trakt list"
+		l.Error().Msg(errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
 	var titles []string
 
-	if strings.HasSuffix(cfg.URL, ".json") {
-		green := color.New(color.FgGreen).SprintFunc()
-		l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
+	green := color.New(color.FgGreen).SprintFunc()
+	l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
 
-		resp, err := http.Get(cfg.URL)
-		if err != nil {
-			l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.URL)
-			return err
-		}
-		defer resp.Body.Close()
+	resp, err := http.Get(cfg.URL)
+	if err != nil {
+		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.URL)
+		return err
+	}
+	defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusOK {
-			l.Error().Msgf("failed to fetch titles from URL: %s", cfg.URL)
-			return fmt.Errorf("failed to fetch titles from URL: %s", cfg.URL)
-		}
+	if resp.StatusCode != http.StatusOK {
+		l.Error().Msgf("failed to fetch titles from URL: %s", cfg.URL)
+		return fmt.Errorf("failed to fetch titles from URL: %s", cfg.URL)
+	}
 
-		var data []struct {
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		errMsg := fmt.Sprintf("invalid content type for URL: %s, content type should be application/json", cfg.URL)
+		return fmt.Errorf(errMsg)
+	}
+
+	var data []struct {
+		Title string `json:"title"`
+		Movie struct {
 			Title string `json:"title"`
-			Movie struct {
-				Title string `json:"title"`
-			} `json:"movie"`
-			Show struct {
-				Title string `json:"title"`
-			} `json:"show"`
-		}
+		} `json:"movie"`
+		Show struct {
+			Title string `json:"title"`
+		} `json:"show"`
+	}
 
-		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-			l.Error().Err(err).Msgf("failed to decode JSON data from URL: %s", cfg.URL)
-			return err
-		}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		l.Error().Err(err).Msgf("failed to decode JSON data from URL: %s", cfg.URL)
+		return err
+	}
 
-		for _, item := range data {
-			titles = append(titles, item.Title)
-			if item.Movie.Title != "" {
-				titles = append(titles, item.Movie.Title)
-			}
-			if item.Show.Title != "" {
-				titles = append(titles, item.Show.Title)
-			}
+	for _, item := range data {
+		titles = append(titles, item.Title)
+		if item.Movie.Title != "" {
+			titles = append(titles, item.Movie.Title)
 		}
-
+		if item.Show.Title != "" {
+			titles = append(titles, item.Show.Title)
+		}
 	}
 
 	for _, filterID := range cfg.Filters {

--- a/internal/processor/trakt.go
+++ b/internal/processor/trakt.go
@@ -16,11 +16,6 @@ import (
 func (s Service) trakt(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
 	l := log.With().Str("type", "trakt").Str("client", cfg.Name).Logger()
 
-	// Validate the input URL
-	if !strings.HasPrefix(cfg.URL, "https://sudoer.dev") {
-		return fmt.Errorf("invalid URL provided for Trakt list, URL must start with https://api.autobrr.com/trakt. For supported lists, please refer to the README")
-	}
-
 	if cfg.URL == "" {
 		errMsg := "no URL provided for Trakt list"
 		l.Error().Msg(errMsg)
@@ -88,13 +83,7 @@ func (s Service) trakt(ctx context.Context, cfg *domain.ListConfig, dryRun bool,
 		l.Trace().Msgf("%s", joinedTitles)
 
 		if len(joinedTitles) == 0 {
-			if strings.Contains(cfg.URL, "mdblist.com") {
-				l.Error().Msgf("Found %s in a Trakt filter", cfg.URL)
-				l.Error().Msgf("Please make sure you have set up the URL as \"type: mdblist\" in the config")
-			} else {
-				l.Error().Msgf("Found no titles in %s", cfg.URL)
-				l.Error().Msgf("Are you sure this is a trakt.tv JSON?")
-			}
+			l.Debug().Msgf("no titles found for filter: %v", filterID)
 			return nil
 		}
 

--- a/internal/processor/trakt.go
+++ b/internal/processor/trakt.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/autobrr/omegabrr/internal/domain"
 	"github.com/autobrr/omegabrr/pkg/autobrr"
+
 	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
 )
@@ -27,7 +28,19 @@ func (s Service) trakt(ctx context.Context, cfg *domain.ListConfig, dryRun bool,
 	green := color.New(color.FgGreen).SprintFunc()
 	l.Debug().Msgf("fetching titles from %s", green(cfg.URL))
 
-	resp, err := http.Get(cfg.URL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.URL, nil)
+	if err != nil {
+		l.Error().Err(err).Msg("could not make new request")
+		return err
+	}
+
+	req.Header.Set("trakt-api-version", "2")
+	//req.Header.Set("trakt-api-key", t.apiKey)
+	for k, v := range cfg.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		l.Error().Err(err).Msgf("failed to fetch titles from URL: %s", cfg.URL)
 		return err

--- a/internal/processor/trakt.go
+++ b/internal/processor/trakt.go
@@ -103,7 +103,7 @@ func (s Service) trakt(ctx context.Context, cfg *domain.ListConfig, dryRun bool,
 		if !dryRun {
 			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
 				l.Error().Err(err).Msgf("something went wrong updating filter: %v", filterID)
-				continue
+				return fmt.Errorf("error updating filter: %v, %w", filterID, err)
 			}
 		}
 

--- a/internal/processor/trakt.go
+++ b/internal/processor/trakt.go
@@ -16,6 +16,11 @@ import (
 func (s Service) trakt(ctx context.Context, cfg *domain.ListConfig, dryRun bool, brr *autobrr.Client) error {
 	l := log.With().Str("type", "trakt").Str("client", cfg.Name).Logger()
 
+	// Validate the input URL
+	if !strings.HasPrefix(cfg.URL, "https://api.autobrr.com/trakt") {
+		return fmt.Errorf("invalid URL provided for Trakt list, URL must start with https://api.autobrr.com/trakt. For supported lists, please refer to the README")
+	}
+
 	if cfg.URL == "" {
 		errMsg := "no URL provided for Trakt list"
 		l.Error().Msg(errMsg)

--- a/internal/processor/trakt_test.go
+++ b/internal/processor/trakt_test.go
@@ -15,6 +15,7 @@ import (
 func TestTraktList(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Return sample JSON response for testing
+		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintln(w, `[{"title": "Movie 1", "movie": {"title": "Movie 1 Title"}}, {"title": "Movie 2", "show": {"title": "Show 1 Title"}}]`)
 	}))
 	defer ts.Close()

--- a/internal/processor/trakt_test.go
+++ b/internal/processor/trakt_test.go
@@ -21,12 +21,13 @@ func TestTraktList(t *testing.T) {
 
 	cfg := &domain.ListConfig{
 		Name: "test",
-		URL:  "https://api.autobrr.com/lists/trakt/anticipated-tv",
+		//URL:  "https://api.autobrr.com/lists/trakt/anticipated-tv",
+		URL: ts.URL,
 	}
 
 	brr := &autobrr.Client{}
 
-	service := Service{}
+	service := NewService(nil)
 
 	err := service.trakt(context.Background(), cfg, false, brr)
 	if err != nil {

--- a/internal/processor/trakt_test.go
+++ b/internal/processor/trakt_test.go
@@ -11,19 +11,6 @@ import (
 	"github.com/autobrr/omegabrr/pkg/autobrr"
 )
 
-// Tests that an error is returned when an invalid URL is passed to the `trakt` function
-func TestTrakt_InvalidURL(t *testing.T) {
-
-	s := Service{}
-
-	cfg := &domain.ListConfig{Name: "test list", URL: "http://example.com"}
-
-	err := s.trakt(context.Background(), cfg, false, nil)
-	if err == nil {
-		t.Error("expected error, got nil")
-	}
-}
-
 // Unit test for the `trakt` function with mocked dependencies.
 func TestTraktList(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/processor/trakt_test.go
+++ b/internal/processor/trakt_test.go
@@ -21,7 +21,7 @@ func TestTraktList(t *testing.T) {
 
 	cfg := &domain.ListConfig{
 		Name: "test",
-		URL:  "https://sudoer.dev/ant.json",
+		URL:  "https://api.autobrr.com/lists/trakt/anticipated-tv",
 	}
 
 	brr := &autobrr.Client{}

--- a/internal/processor/trakt_test.go
+++ b/internal/processor/trakt_test.go
@@ -1,0 +1,48 @@
+package processor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/autobrr/omegabrr/internal/domain"
+	"github.com/autobrr/omegabrr/pkg/autobrr"
+)
+
+// Tests that an error is returned when an invalid URL is passed to the `trakt` function
+func TestTrakt_InvalidURL(t *testing.T) {
+
+	s := Service{}
+
+	cfg := &domain.ListConfig{Name: "test list", URL: "http://example.com"}
+
+	err := s.trakt(context.Background(), cfg, false, nil)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+// Unit test for the `trakt` function with mocked dependencies.
+func TestTraktList(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return sample JSON response for testing
+		fmt.Fprintln(w, `[{"title": "Movie 1", "movie": {"title": "Movie 1 Title"}}, {"title": "Movie 2", "show": {"title": "Show 1 Title"}}]`)
+	}))
+	defer ts.Close()
+
+	cfg := &domain.ListConfig{
+		Name: "test",
+		URL:  "https://sudoer.dev/ant.json",
+	}
+
+	brr := &autobrr.Client{}
+
+	service := Service{}
+
+	err := service.trakt(context.Background(), cfg, false, brr)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Feature: Lists Support

This pull request adds support for importing titles from lists in json and plaintext format, and thus allowing the powerful regex processing from title.go to be used for these lists. The following endpoints have been tested and are confirmed to work:

- https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json `type: mdblist`
- https://api.r4tio.dev/metacritic/upcoming-albums `type: metacritic`
- https://api.r4tio.dev/metacritic/new-albums `type: metacritic`
- https://bin.r4tio.dev/raw/iruripobuk `type: plaintext`
- https://sudoer.dev/movies.json `type: trakt`
- https://sudoer.dev/bluray.json `type: trakt`
- https://sudoer.dev/ant.json `type: trakt`
- https://sudoer.dev/tv.json `type: trakt`
- https://sudoer.dev/slu.json `type: trakt`

Example config:
```yaml
  lists:
    - name: trakt-anticipated
      type: trakt
      url: https://sudoer.dev/ant.json
      filters:
        - 17
    - name: latest-tv-shows
      type: mdblist
      url: https://mdblist.com/lists/garycrawfordgc/latest-tv-shows/json
      filters:
        - 18
    - name: custom-titles-line-by-line
      type: plaintext
      url: https://bin.r4tio.dev/raw/iruripobuk # plaintext line by line
      filters:
        - 19
    - name: Upcoming albums
      type: metacritic
      url: https://api.r4tio.dev/metacritic/upcoming-albums
      filters:
        - 20
```

### Possible improvements
- ~~Set regbrr as a separate service (eg. arr and regbrr) or rename the current one to something like `service`~~
- [x] - Utilize brr api as a middleman for the regbrr jsons