### PR TITLE
feat(plaintext): add option to use Album & MatchRelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,19 @@ Readarr will only use the `Match releases` field for now, so setting `matchRelea
 
 You can drop alternate show titles from being added by setting `excludeAlternateTitles: true` for Sonarr in your config.
 
+## Plaintext lists specific options
+
+Plaintext lists can be anything, therefore you can optionally set `matchRelease: true` or `album: true` to use these fields in your autobrr filter. If not set, it will use the `Movies / Shows` field.
+
+```yaml
+lists:
+  - name: Personal list
+    type: plaintext
+    url: https://gist.githubusercontent.com/autobrr/somegist/raw
+    filters:
+      - 27 # change me
+```
+
 ## Commands
 
 Available commands.

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -27,6 +27,7 @@ type ListConfig struct {
 	BasicAuth    *BasicAuth        `koanf:"basicAuth"`
 	Filters      []int             `koanf:"filters"`
 	MatchRelease bool              `koanf:"matchRelease"`
+	Album        bool              `koanf:"album"`
 	Headers      map[string]string `koanf:"headers"`
 }
 

--- a/internal/processor/plaintext.go
+++ b/internal/processor/plaintext.go
@@ -88,7 +88,13 @@ func (s Service) plaintext(ctx context.Context, cfg *domain.ListConfig, dryRun b
 			return nil
 		}
 
-		f := autobrr.UpdateFilter{Shows: strings.Join(filterTitles, ",")}
+		f := autobrr.UpdateFilter{Shows: joinedTitles}
+
+		if cfg.Album {
+			f = autobrr.UpdateFilter{Albums: joinedTitles}
+		} else if cfg.MatchRelease {
+			f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
+		}
 
 		if !dryRun {
 			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {


### PR DESCRIPTION
Since Plaintext can be any type of list, I added the option to use Album or MatchRelease as well as the default Shows field.