### PR TITLE
enhancement(parsing): handle non-standard space characters

### DIFF
--- a/internal/processor/title.go
+++ b/internal/processor/title.go
@@ -19,7 +19,7 @@ func processTitle(title string, matchRelease bool) []string {
 	t := NewTitleSlice()
 
 	// Regex patterns
-	replaceRegexp := regexp.MustCompile(`[[:punct:][:space:]à-üÀ-Ü]`)
+	replaceRegexp := regexp.MustCompile(`[[:punct:]\s\x{00a0}\x{2000}-\x{200f}\x{2028}-\x{202f}\x{205f}-\x{206f}à-üÀ-Ü]`)
 	questionmarkRegexp := regexp.MustCompile(`[?]{2,}`)
 	regionCodeRegexp := regexp.MustCompile(`\(.+\)$`)
 	parenthesesEndRegexp := regexp.MustCompile(`\)$`)

--- a/internal/processor/title_test.go
+++ b/internal/processor/title_test.go
@@ -187,10 +187,10 @@ func Test_processTitle(t *testing.T) {
 		{
 			name: "test_22",
 			args: args{
-				title:        "A\u00a0Quiet\u00a0Place:\u00a0 Part II",
+				title:        "A\u00a0Quiet\u00a0Place:\u00a0Day One",
 				matchRelease: false,
 			},
-			want: []string{"A?Quiet?Place*Part?II"},
+			want: []string{"A?Quiet?Place*Day?One"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/processor/title_test.go
+++ b/internal/processor/title_test.go
@@ -184,6 +184,14 @@ func Test_processTitle(t *testing.T) {
 			},
 			want: []string{"-!"},
 		},
+		{
+			name: "test_22",
+			args: args{
+				title:        "A\u00a0Quiet\u00a0Place:\u00a0 Part II",
+				matchRelease: false,
+			},
+			want: []string{"A?Quiet?Place*Part?II"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes handling of non-breaking space and other non-standard space characters.

Example:
`A Quiet Place: Day One` has a non-breaking space after the colon when pulled from Radarr, Trakt and Mdblists. This resulted in the parsed title ending up as `A?Quiet?Place? Day?One` instead of `A?Quiet?Place*Day?One`