### PR TITLE
enhancement: retain parenthesized year in titles array

### DIFF
--- a/internal/processor/title.go
+++ b/internal/processor/title.go
@@ -13,8 +13,8 @@ func processTitle(title string, matchRelease bool) []string {
 	}
 
 	// cleans year like (2020) from arr title
-	var re = regexp.MustCompile(`(?m)\s(\(\d+\))`)
-	title = re.ReplaceAllString(title, "")
+	//var re = regexp.MustCompile(`(?m)\s(\(\d+\))`)
+	//title = re.ReplaceAllString(title, "")
 
 	t := NewTitleSlice()
 

--- a/internal/processor/title_test.go
+++ b/internal/processor/title_test.go
@@ -22,7 +22,7 @@ func Test_processTitle(t *testing.T) {
 				title:        "The Quick Brown Fox (2022)",
 				matchRelease: false,
 			},
-			want: []string{"The?Quick?Brown?Fox"},
+			want: []string{"The?Quick?Brown?Fox", "The?Quick?Brown?Fox*2022", "The?Quick?Brown?Fox*2022?"},
 		},
 		{
 			name: "test_02",
@@ -30,7 +30,7 @@ func Test_processTitle(t *testing.T) {
 				title:        "The Matrix     -        Reloaded (2929)",
 				matchRelease: false,
 			},
-			want: []string{"The?Matrix*Reloaded"},
+			want: []string{"The?Matrix*Reloaded", "The?Matrix*Reloaded*2929", "The?Matrix*Reloaded*2929?"},
 		},
 		{
 			name: "test_03",
@@ -38,7 +38,7 @@ func Test_processTitle(t *testing.T) {
 				title:        "The Matrix -(Test)- Reloaded (2929)",
 				matchRelease: false,
 			},
-			want: []string{"The?Matrix*Test*Reloaded"},
+			want: []string{"The?Matrix*", "The?Matrix", "The?Matrix*Test*Reloaded*2929?", "The?Matrix*Test*Reloaded*2929"},
 		},
 		{
 			name: "test_04",
@@ -54,7 +54,7 @@ func Test_processTitle(t *testing.T) {
 				title:        "Arrr!! The Title (2020)",
 				matchRelease: false,
 			},
-			want: []string{"Arrr*The?Title"},
+			want: []string{"Arrr*The?Title", "Arrr*The?Title*2020", "Arrr*The?Title*2020?"},
 		},
 		{
 			name: "test_06",
@@ -191,6 +191,14 @@ func Test_processTitle(t *testing.T) {
 				matchRelease: false,
 			},
 			want: []string{"A?Quiet?Place*Day?One"},
+		},
+		{
+			name: "test_23",
+			args: args{
+				title:        "Whose Line Is It Anyway? (US) (1932)",
+				matchRelease: false,
+			},
+			want: []string{"Whose?Line?Is?It?Anyway", "Whose?Line?Is?It?Anyway?", "Whose?Line?Is?It?Anyway*US*1932", "Whose?Line?Is?It?Anyway*US*1932?"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Shows like `Cosmos (2014)` needs the year included to differentiate it from the 1980 version.
Don't think its an issue for announces in the scene naming format, but some indexers announce them like this:
`Cosmos (2014) S01E02` instead of `Cosmos.2014.S01.E02`. This should resolve that.

It will add one with and without the year. Just like with titles containing eg.`(US)`.

```
2023-05-03T01:31:01+02:00 TRC Breaking?Bad,The?Office*US?,The?Office*US,The?Office,
Cosmos*2014?,Cosmos*2014,Cosmos client=radarr type=sonarr
```