### PR TITLE
fix(whisparr): swap to sonarr base

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ clients:
       apikey: YOUR_API_KEY
       filters:
         - 69 # Change me
-      #matchRelease: false / true
+      matchRelease: true # needed as we grab site names
 
 lists:
   - name: Latest TV Shows

--- a/config.yml
+++ b/config.yml
@@ -59,7 +59,7 @@ clients:
       apikey: API_KEY
       filters:
         - 69 # Change me
-      #matchRelease: false / true
+      matchRelease: true # needed as we grab site names
 
 lists:
   - name: Latest TV Shows

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -267,7 +267,7 @@ clients:
     #  type: whisparr
     #  host: http://localhost:6969
     #  apikey: API_KEY
-	#  matchRelease: true
+    #  matchRelease: true
     #  filters:
     #    - 69 # Change me
 

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -267,6 +267,7 @@ clients:
     #  type: whisparr
     #  host: http://localhost:6969
     #  apikey: API_KEY
+	#  matchRelease: true
     #  filters:
     #    - 69 # Change me
 

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -64,7 +64,7 @@ func (s Service) ProcessArrs(ctx context.Context, dryRun bool) []string {
 				}
 
 			case domain.ArrTypeWhisparr:
-				if err := s.radarr(ctx, arrClient, dryRun, a); err != nil {
+				if err := s.sonarr(ctx, arrClient, dryRun, a); err != nil {
 					log.Error().Err(err).Str("type", "whisparr").Str("client", arrClient.Name).Msg("error while processing Whisparr, continuing with other clients")
 					processingErrors = append(processingErrors, fmt.Sprintf("Whisparr - %s: %v", arrClient.Name, err))
 				}


### PR DESCRIPTION
We grab the site names from Whisparr V2.

`matchRelease: true` is therefore recommended. Could be hardcoded, but seemed silly to make a separate whisparr.go when it's using the Sonarr base anyway.