### PR TITLE
fix(lidarr): Monitored artists and albums

### DIFF
--- a/internal/processor/lidarr.go
+++ b/internal/processor/lidarr.go
@@ -119,8 +119,6 @@ func (s Service) processLidarr(ctx context.Context, cfg *domain.ArrConfig, logge
 				seenArtists[artist.ArtistName] = struct{}{}
 				logger.Debug().Msgf("Added artist: %s", artist.ArtistName) // Log when an artist is added
 			}
-		} else {
-			logger.Debug().Msgf("Artist not monitored: %s", artist.ArtistName) // Log if artist is not monitored
 		}
 	}
 

--- a/internal/processor/lidarr.go
+++ b/internal/processor/lidarr.go
@@ -20,30 +20,44 @@ func (s Service) lidarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 
 	l.Debug().Msgf("gathering titles...")
 
-	titles, err := s.processLidarr(ctx, cfg, &l)
+	titles, artists, err := s.processLidarr(ctx, cfg, &l)
 	if err != nil {
 		return err
 	}
 
 	l.Debug().Msgf("got %v filter titles", len(titles))
 
-	joinedTitles := strings.Join(titles, ",")
+	// Process titles
+	var processedTitles []string
+	for _, title := range titles {
+		processedTitles = append(processedTitles, processTitle(title, cfg.MatchRelease)...)
+	}
 
-	l.Trace().Msgf("%v", joinedTitles)
+	// Update filter based on MatchRelease
+	var f autobrr.UpdateFilter
+	if cfg.MatchRelease {
+		joinedTitles := strings.Join(processedTitles, ",")
+		if len(joinedTitles) == 0 {
+			return nil
+		}
+		f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
+	} else {
+		// Process artists only if MatchRelease is false
+		var processedArtists []string
+		for _, artist := range artists {
+			processedArtists = append(processedArtists, processTitle(artist, cfg.MatchRelease)...)
+		}
 
-	if len(joinedTitles) == 0 {
-		return nil
+		joinedTitles := strings.Join(processedTitles, ",")
+		joinedArtists := strings.Join(processedArtists, ",")
+		if len(joinedTitles) == 0 && len(joinedArtists) == 0 {
+			return nil
+		}
+		f = autobrr.UpdateFilter{Albums: joinedTitles, Artists: joinedArtists}
 	}
 
 	for _, filterID := range cfg.Filters {
-
 		l.Debug().Msgf("updating filter: %v", filterID)
-
-		f := autobrr.UpdateFilter{Albums: joinedTitles}
-
-		if cfg.MatchRelease {
-			f = autobrr.UpdateFilter{MatchReleases: joinedTitles}
-		}
 
 		if !dryRun {
 			if err := brr.UpdateFilterByID(ctx, filterID, f); err != nil {
@@ -53,13 +67,12 @@ func (s Service) lidarr(ctx context.Context, cfg *domain.ArrConfig, dryRun bool,
 		}
 
 		l.Debug().Msgf("successfully updated filter: %v", filterID)
-
 	}
 
 	return nil
 }
 
-func (s Service) processLidarr(ctx context.Context, cfg *domain.ArrConfig, logger *zerolog.Logger) ([]string, error) {
+func (s Service) processLidarr(ctx context.Context, cfg *domain.ArrConfig, logger *zerolog.Logger) ([]string, []string, error) {
 	c := starr.New(cfg.Apikey, cfg.Host, 60*time.Second)
 
 	if cfg.BasicAuth != nil {
@@ -73,69 +86,45 @@ func (s Service) processLidarr(ctx context.Context, cfg *domain.ArrConfig, logge
 
 	r := lidarr.New(c)
 
-	//		TAGS NOT SUPPORTED FOR ALBUMS APPARENTLY
-	//
-	//	var tags []*starr.Tag
-	//	if len(cfg.TagsExclude) > 0 || len(cfg.TagsInclude) > 0 {
-	//		t, err := r.GetTagsContext(ctx)
-	//		if err != nil {
-	//			logger.Debug().Msg("could not get tags")
-	//		}
-	//		tags = t
-	//	}
-
 	albums, err := r.GetAlbumContext(ctx, "")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
-	logger.Debug().Msgf("found %d releases to process", len(albums))
 
 	var titles []string
-	var monitoredTitles int
+	var artists []string
+	seenArtists := make(map[string]struct{})
 
 	for _, album := range albums {
-		m := album
-
-		// only want monitored
-		if !m.Monitored {
-			continue
+		if !album.Monitored {
+			continue // Skip unmonitored albums
 		}
 
-		//		TAGS NOT SUPPORTED FOR ALBUMS APPARENTLY
-		//
-		//		if len(cfg.TagsInclude) > 0 {
-		//			if len(s.Tags) == 0 {
-		//				continue
-		//			}
-		//			if !containsTag(tags, s.Tags, cfg.TagsInclude) {
-		//				continue
-		//			}
-		//		}
-		//
-		//		if len(cfg.TagsExclude) > 0 {
-		//			if containsTag(tags, s.Tags, cfg.TagsExclude) {
-		//				continue
-		//			}
-		//		}
+		// Fetch the artist details
+		artist, err := r.GetArtistByIDContext(ctx, album.ArtistID)
+		if err != nil {
+			logger.Error().Err(err).Msgf("Error fetching artist details for album: %v", album.Title)
+			continue // Skip this album if there's an error fetching the artist
+		}
 
-		// increment monitored titles
-		monitoredTitles++
+		if artist.Monitored {
+			processedTitles := processTitle(album.Title, cfg.MatchRelease)
+			titles = append(titles, processedTitles...)
 
-		//titles = append(titles, rls.MustNormalize(m.Title))
-		//titles = append(titles, rls.MustNormalize(m.OriginalTitle))
-		//titles = append(titles, rls.MustClean(m.Title))
+			// Debug logging
+			logger.Debug().Msgf("Processing artist: %s", artist.ArtistName)
 
-		titles = append(titles, processTitle(m.Title, cfg.MatchRelease)...)
-
-		//	titles = append(titles, processTitle(m.OriginalTitle)...)
-
-		//for _, title := range m.AlternateTitles {
-		//	titles = append(titles, processTitle(title.Title)...)
-		//}
+			if _, exists := seenArtists[artist.ArtistName]; !exists {
+				artists = append(artists, artist.ArtistName)
+				seenArtists[artist.ArtistName] = struct{}{}
+				logger.Debug().Msgf("Added artist: %s", artist.ArtistName) // Log when an artist is added
+			}
+		} else {
+			logger.Debug().Msgf("Artist not monitored: %s", artist.ArtistName) // Log if artist is not monitored
+		}
 	}
 
-	logger.Debug().Msgf("from a total of %d releases we found %d monitored and created %d release titles", len(albums), monitoredTitles, len(titles))
+	logger.Debug().Msgf("Processed %d monitored albums with monitored artists, created %d titles, found %d unique artists", len(titles), len(titles), len(artists))
 
-	return titles, nil
+	return titles, artists, nil
 }

--- a/internal/processor/title.go
+++ b/internal/processor/title.go
@@ -79,7 +79,9 @@ func NewTitleSlice() *Titles {
 }
 
 func (ts *Titles) Add(title string, matchRelease bool) {
+
 	if matchRelease {
+		title = strings.Trim(title, "?")
 		title = fmt.Sprintf("*%v*", title)
 	}
 


### PR DESCRIPTION
This PR addresses an issue in the Lidarr processing logic where it was fetching monitored albums from both unmonitored and monitored artists. The issue caused the titles of unmonitored artists' albums to be included in the processing, which was not the intended behavior.

### Changes Made

- Modified the Lidarr processing logic to only fetch monitored albums from monitored artists.
- Added the monitored artists to the Artists field for processing.
- Trim any leading or trailing `?` from the processed title if matchRelease=true.