### PR TITLE
fix(processor): `What If` not getting processed correctly

### DIFF
--- a/internal/processor/title.go
+++ b/internal/processor/title.go
@@ -19,7 +19,7 @@ func processTitle(title string, matchRelease bool) []string {
 	t := NewTitleSlice()
 
 	// Regex patterns
-	replaceRegexp := regexp.MustCompile(`[[:punct:]\s\x{00a0}\x{2000}-\x{200f}\x{2028}-\x{202f}\x{205f}-\x{206f}à-üÀ-Ü]`)
+	replaceRegexp := regexp.MustCompile(`[[:punct:]\s\x{00a0}\x{2000}-\x{200f}\x{2026}-\x{202f}\x{205f}-\x{206f}à-üÀ-Ü]`)
 	questionmarkRegexp := regexp.MustCompile(`[?]{2,}`)
 	regionCodeRegexp := regexp.MustCompile(`\(.+\)$`)
 	parenthesesEndRegexp := regexp.MustCompile(`\)$`)

--- a/internal/processor/title_test.go
+++ b/internal/processor/title_test.go
@@ -200,6 +200,14 @@ func Test_processTitle(t *testing.T) {
 			},
 			want: []string{"Whose?Line?Is?It?Anyway", "Whose?Line?Is?It?Anyway?", "Whose?Line?Is?It?Anyway*US*1932", "Whose?Line?Is?It?Anyway*US*1932?"},
 		},
+		{
+			name: "test_24",
+			args: args{
+				title:        "What If…?",
+				matchRelease: false,
+			},
+			want: []string{"What?If", "What?If*"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The show title `What If…?` was not getting processed correctly because of the unique punctuation `…`.

Included the hex code in the replace regex and added a test.