### PR TITLE
fix(build): binary asset names and build vars

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,8 @@ builds:
         goarch: arm64
     main: ./cmd/omegabrr/main.go
     binary: omegabrr
+    ldflags:
+      - -s -w -X github.com/autobrr/omegabrr/internal/buildinfo.Version=v{{.Version}} -X github.com/autobrr/omegabrr/internal/buildinfo.Commit={{.Commit}} -X github.com/autobrr/omegabrr/internal/buildinfo.Date={{.Date}} -X github.com/autobrr/omegabrr/internal/buildinfo.BuiltBy=goreleaser'
 
 archives:
   - id: omegabrr

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,12 +38,6 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- .Version }}_
-      {{- .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else }}{{ .Arch }}{{ end }}
 
 release:
   prerelease: auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY . ./
 #ENV GOOS=linux
 ENV CGO_ENABLED=0
 
-RUN go build -ldflags "-s -w -X buildinfo.Version=${VERSION} -X buildinfo.Commit=${REVISION} -X buildinfo.Date=${BUILDTIME}" -o bin/omegabrr cmd/omegabrr/main.go
+RUN go build -ldflags "-s -w -X github.com/autobrr/omegabrr/internal/buildinfo.Version=${VERSION} -X github.com/autobrr/omegabrr/internal/buildinfo.Commit=${REVISION} -X github.com/autobrr/omegabrr/internal/buildinfo.Date=${BUILDTIME}" -o bin/omegabrr cmd/omegabrr/main.go
 
 # build runner
 FROM alpine:latest

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -24,7 +24,7 @@ export GOARCH=$TARGETARCH; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v6" ]] && export GOARM=6; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v7" ]] && export GOARM=7; \
 echo $GOARCH $GOOS $GOARM$GOAMD64; \
-go build -ldflags "-s -w -X buildinfo.Version=${VERSION} -X buildinfo.Commit=${REVISION} -X buildinfo.Date=${BUILDTIME}" -o /out/bin/omegabrr cmd/omegabrr/main.go
+go build -ldflags "-s -w -X github.com/autobrr/omegabrr/internal/buildinfo.Version=${VERSION} -X github.com/autobrr/omegabrr/internal/buildinfo.Commit=${REVISION} -X github.com/autobrr/omegabrr/internal/buildinfo.Date=${BUILDTIME}" -o /out/bin/omegabrr cmd/omegabrr/main.go
 
 # build runner
 FROM alpine:latest AS runner

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GIT_TAG := $(shell git tag --points-at HEAD 2> /dev/null | head -n 1)
 
 GO ?= go
 RM ?= rm
-GOFLAGS ?= "-X buildinfo.Commit=$(GIT_COMMIT) -X buildinfo.Version=$(GIT_TAG)"
+GOFLAGS ?= "-X github.com/autobrr/omegabrr/internal/buildinfo.Commit=$(GIT_COMMIT) -X github.com/autobrr/omegabrr/internal/buildinfo.Version=$(GIT_TAG)"
 PREFIX ?= /usr/local
 BINDIR ?= bin
 


### PR DESCRIPTION
Removes the custom goreleaser `name_template` to make the update command work correctly and find binaries.

Also change the build vars to use full package path.